### PR TITLE
Change workflow to use local action

### DIFF
--- a/.github/workflows/snap-testing.yml
+++ b/.github/workflows/snap-testing.yml
@@ -18,14 +18,17 @@ jobs:
             repo: edgexfoundry/device-mqtt-go
 
     steps:
+      - name: Checkout the local actions
+        uses: actions/checkout@v2
+
       - name: Build and upload snap
         id: build
-        uses: canonical/edgex-snap-testing/build@multiple-actions
+        uses: ./build
         with:
           repo: ${{matrix.repo}}
 
       - name: Download and test snap
-        uses: canonical/edgex-snap-testing/test@multiple-actions
+        uses: ./test
         with:
           name: device-mqtt
           snap: ${{steps.build.outputs.snap}}

--- a/.github/workflows/snap-testing.yml
+++ b/.github/workflows/snap-testing.yml
@@ -17,6 +17,7 @@ jobs:
           - name: device-mqtt
             repo: edgexfoundry/device-mqtt-go
 
+    # use local actions to build and test
     steps:
       - name: Checkout the local actions
         uses: actions/checkout@v2
@@ -26,6 +27,9 @@ jobs:
         uses: ./build
         with:
           repo: ${{matrix.repo}}
+
+      - name: Checkout the local actions again
+        uses: actions/checkout@v2
 
       - name: Download and test snap
         uses: ./test


### PR DESCRIPTION
Use the actions available locally. This is to allow running updated tests in PRs.