### PR TITLE
Install snaps from store when testing in local workflow

### DIFF
--- a/.github/workflows/snap-testing.yml
+++ b/.github/workflows/snap-testing.yml
@@ -15,10 +15,8 @@ jobs:
       matrix:
         include:
           - name: device-mqtt
-            repo: edgexfoundry/device-mqtt-go
 
           - name: ekuiper
-            repo: canonical/edgex-ekuiper-snap
             channel: 1/edge
 
     # use local action to test

--- a/.github/workflows/snap-testing.yml
+++ b/.github/workflows/snap-testing.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout the local actions again
         uses: actions/checkout@v2
 
-      - name: Download and test snap
+      - name: Test snap
         uses: ./test
         with:
           name: ${{matrix.name}}

--- a/.github/workflows/snap-testing.yml
+++ b/.github/workflows/snap-testing.yml
@@ -16,19 +16,15 @@ jobs:
         include:
           - name: device-mqtt
             repo: edgexfoundry/device-mqtt-go
+
           - name: ekuiper
             repo: canonical/edgex-ekuiper-snap
+            channel: 1/edge
 
-    # use local actions to build and test
+    # use local action to test
     steps:
       - name: Checkout the local actions
         uses: actions/checkout@v2
-
-      - name: Build and upload snap
-        id: build
-        uses: ./build
-        with:
-          repo: ${{matrix.repo}}
 
       - name: Checkout the local actions again
         uses: actions/checkout@v2
@@ -37,4 +33,4 @@ jobs:
         uses: ./test
         with:
           name: ${{matrix.name}}
-          snap: ${{steps.build.outputs.snap}}
+          channel: ${{matrix.channel}}

--- a/.github/workflows/snap-testing.yml
+++ b/.github/workflows/snap-testing.yml
@@ -12,6 +12,7 @@ jobs:
     name: Build & Test
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - name: device-mqtt

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Use environment variables, as defined in [env/env.go](./env/env.go)
 ## Test using Github Actions
 This project includes two Github Actions that can be used in workflows to test snaps:
 * [build](./build): Checkout code, build the snap, and upload snap as build artifact
-* [test](./test): Download the snap from artifacts (optional), and run smoke tests
+* [test](./test): Download the snap from build artifacts (optional) and run smoke tests
 
 A workflow that uses both the actions from `main` branch may look as follows:
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Use environment variables, as defined in [env/env.go](./env/env.go)
 
 ## Test using Github Actions
 This project includes two Github Actions that can be used in workflows to test snaps:
-* [build](./build): Checkout code, build the snap, upload snap as build artifact
-* [test](./test): Download snap, run smoke tests
+* [build](./build): Checkout code, build the snap, and upload snap as build artifact
+* [test](./test): Download the snap from artifacts (optional), and run smoke tests
 
 A workflow that uses both the actions from `main` branch may look as follows:
 

--- a/test/action.yml
+++ b/test/action.yml
@@ -22,23 +22,23 @@ runs:
 
   steps:
     # Download the snap from build artifacts
-    - if: ${{inputs.snap}}
+    - if: ${{inputs.snap != ''}}
       uses: actions/download-artifact@v2
       with:
         name: ${{inputs.snap}}
 
     # Set the absolute path
-    - if: ${{inputs.snap}}
+    - if: ${{inputs.snap != ''}}
       shell: bash
       id: path
       run: |
-        echo ::set-output local_snap=${{github.workspace}}/${{inputs.snap}}
+        echo "::set-output name=local_snap::${{github.workspace}}/${{inputs.snap}}"
 
     # Run smoke tests
     - shell: bash
       working-directory: ${{github.action_path}}
       env:
         LOCAL_SNAP: ${{steps.path.outputs.local_snap}}
-        SERVICE_CHANNEL: ${{inputs.snap}}
+        SERVICE_CHANNEL: ${{inputs.channel}}
       run: |
         go test -p 1 -v ./suites/${{inputs.name}}

--- a/test/action.yml
+++ b/test/action.yml
@@ -1,9 +1,10 @@
 name: EdgeX Snap Tester
 description: |
-  Github action downloads a snap and runs various smoke tests
-  to validate the snap packaging.
+  This Github action runs various smoke tests to validate the snap packaging.
 
-  The snap can be optionally downloaded from build artifacts.
+  When 'snap' input is set, the snap is downloaded from build artifacts and
+  its absolute path is passed to the tests.
+  In this case, the value of channel is not used.
 
 inputs:
   name:
@@ -13,7 +14,9 @@ inputs:
     description: Relative path to local snap
     required: false
   channel:
-    description: Channel for downloading the snap from store
+    description: |
+      Channel for downloading the snap from store.
+      This is useful only when 'snap' input is not set.
     required: false
     default: latest/edge
 

--- a/test/action.yml
+++ b/test/action.yml
@@ -1,7 +1,9 @@
 name: EdgeX Snap Tester
 description: |
-  Github action downloads a locally built snap and runs various smoke tests
-  to validate the snap packaging
+  Github action downloads a snap and runs various smoke tests
+  to validate the snap packaging.
+
+  The snap can be optionally downloaded from build artifacts.
 
 inputs:
   name:
@@ -9,21 +11,34 @@ inputs:
     required: true
   snap:
     description: Relative path to local snap
-    required: true
+    required: false
+  channel:
+    description: Channel for downloading the snap from store
+    required: false
+    default: latest/edge
 
 runs:
   using: composite
 
   steps:
     # Download the snap from build artifacts
-    - uses: actions/download-artifact@v2
+    - if: ${{inputs.snap}}
+      uses: actions/download-artifact@v2
       with:
         name: ${{inputs.snap}}
+
+    # Set the absolute path
+    - if: ${{inputs.snap}}
+      shell: bash
+      id: path
+      run: |
+        echo ::set-output local_snap=${{github.workspace}}/${{inputs.snap}}
 
     # Run smoke tests
     - shell: bash
       working-directory: ${{github.action_path}}
       env:
-        LOCAL_SNAP: ${{github.workspace}}/${{inputs.snap}}
+        LOCAL_SNAP: ${{steps.path.outputs.local_snap}}
+        SERVICE_CHANNEL: ${{inputs.snap}}
       run: |
         go test -p 1 -v ./suites/${{inputs.name}}


### PR DESCRIPTION
When we create a PR with changes to tests, we tests all snaps to make sure tests pass. The snaps are built from source which is unnecessary in most cases since we have the same snap under latest/edge in the store. 

This PR changes the action and local snap-testing workflow so that snaps are installed from the store. This significantly speeds up the workflow runs.