### PR TITLE
Simplify networking tests

### DIFF
--- a/test/suites/device-mqtt/config_test.go
+++ b/test/suites/device-mqtt/config_test.go
@@ -7,11 +7,10 @@ import (
 
 // Deprecated
 func TestEnvConfig(t *testing.T) {
+	// start clean
+	utils.Exec(t, "sudo snap stop edgex-device-mqtt.device-mqtt")
 
 	t.Run("change service port", func(t *testing.T) {
-		// start clean
-		utils.Exec(t, "sudo snap stop edgex-device-mqtt.device-mqtt")
-
 		t.Cleanup(func() {
 			utils.Exec(t, "sudo snap stop edgex-device-mqtt.device-mqtt")
 			utils.Exec(t, "sudo snap unset edgex-device-mqtt env.service.port")

--- a/test/suites/device-mqtt/main_test.go
+++ b/test/suites/device-mqtt/main_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestMain(m *testing.M) {
 
-	log.Println("[GLOBAL SETUP]")
+	log.Println("[SETUP]")
 
 	// start clean
 	utils.SnapRemove(nil,
@@ -35,7 +35,7 @@ func TestMain(m *testing.M) {
 
 	exitCode := m.Run()
 
-	log.Println("[GLOBAL TEARDOWN]")
+	log.Println("[TEARDOWN]")
 
 	if exitCode != 0 {
 		log.Printf("Snap logs:\n%s\n",

--- a/test/suites/device-mqtt/network_test.go
+++ b/test/suites/device-mqtt/network_test.go
@@ -9,39 +9,24 @@ import (
 
 const defaultServicePort = "59982"
 
-func setupSubtestNetworkInterface(t *testing.T) {
-	t.Log("[SUBTEST SETUP]")
-	utils.Exec(t, "sudo snap start --enable edgex-device-mqtt.device-mqtt")
-
-	err := utils.WaitServiceOnline(t, defaultServicePort)
-	require.NoError(t, err, "Error waiting for services to come online.")
-}
-
 func TestNetworkInterface(t *testing.T) {
-	setupSubtestNetworkInterface(t)
-
 	t.Cleanup(func() {
-		t.Log("[SUBTEST CLEANUP]")
-		utils.Exec(t, "sudo snap stop --disable edgex-device-mqtt.device-mqtt")
+		utils.Exec(t, "sudo snap stop edgex-device-mqtt.device-mqtt")
 	})
 
-	t.Run("listen-all-interfaces", func(t *testing.T) {
-		t.Log("Test if the service is listening on all the configured network interfaces which is not allowed")
+	utils.Exec(t, "sudo snap start edgex-device-mqtt.device-mqtt")
 
-		//stdout, stderr, err := utils.Command("sudo lsof -nPi :59982 | { grep \\* || true; }")
-		//utils.CommandLog(t, stdout, stderr, err)
-		//require.Empty(t, stdout, "This service is listening on all the configured network interface which is not allowed.")
+	t.Run("listen default port "+defaultServicePort, func(t *testing.T) {
+		utils.WaitServiceOnline(t, defaultServicePort)
+	})
+
+	t.Run("not listen on all interfaces", func(t *testing.T) {
 		isConnected := utils.PortConnectionAllInterface(t, defaultServicePort)
-		require.False(t, isConnected, "This service is listening on all the configured network interface which is not allowed.")
+		require.False(t, isConnected)
 	})
 
-	t.Run("listen-localhost-interfaces", func(t *testing.T) {
-		t.Log("Test if the service is only bound to the local machine")
-
-		//stdout, stderr, err := utils.Command("sudo lsof -nPi :59982 | { grep 127.0.0.1 || true; }")
-		//utils.CommandLog(t, stdout, stderr, err)
-		//require.NotEmpty(t, stdout, "This service is not bound to the local machine.")
+	t.Run("listen localhost", func(t *testing.T) {
 		isConnected := utils.PortConnectionLocalhost(t, defaultServicePort)
-		require.True(t, isConnected, "This service is listening on all the configured network interface which is not allowed.")
+		require.True(t, isConnected)
 	})
 }

--- a/test/suites/ekuiper/main_test.go
+++ b/test/suites/ekuiper/main_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestMain(m *testing.M) {
 
-	log.Println("[GLOBAL SETUP]")
+	log.Println("[SETUP]")
 
 	// start clean
 	utils.SnapRemove(nil,
@@ -56,7 +56,7 @@ func TestMain(m *testing.M) {
 	exitCode = m.Run()
 
 TEARDOWN:
-	log.Println("[GLOBAL TEARDOWN]")
+	log.Println("[TEARDOWN]")
 
 	if exitCode != 0 {
 		log.Printf("Snap logs:\n%s\n",

--- a/test/suites/ekuiper/network_test.go
+++ b/test/suites/ekuiper/network_test.go
@@ -3,8 +3,6 @@ package test
 import (
 	"edgex-snap-testing/test/utils"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -12,30 +10,18 @@ const (
 	restfulApiPort = "59720"
 )
 
-func setupSubtestNetworkInterface(t *testing.T) {
-	t.Log("[SUBTEST SETUP]")
-	utils.Exec(t, "sudo snap start --enable edgex-ekuiper.kuiper")
-}
-
 func TestNetworkInterface(t *testing.T) {
-	setupSubtestNetworkInterface(t)
-
 	t.Cleanup(func() {
-		t.Log("[SUBTEST CLEANUP]")
-		utils.Exec(t, "sudo snap stop --disable edgex-ekuiper.kuiper")
+		utils.Exec(t, "sudo snap stop edgex-ekuiper.kuiper")
 	})
 
-	t.Run("kuiper-server", func(t *testing.T) {
-		t.Logf("Test if kuiper server is listening on port %s", serverPort)
+	utils.Exec(t, "sudo snap start edgex-ekuiper.kuiper")
 
-		err := utils.WaitServiceOnline(t, serverPort)
-		require.NoErrorf(t, err, "kuiper server is not listening on port %s", serverPort)
+	t.Run("listen default port "+serverPort, func(t *testing.T) {
+		utils.WaitServiceOnline(t, serverPort)
 	})
 
-	t.Run("restful-api", func(t *testing.T) {
-		t.Logf("Test if restful api is listening on port %s", restfulApiPort)
-
-		err := utils.WaitServiceOnline(t, restfulApiPort)
-		require.NoErrorf(t, err, "restful api is not listening on port %s", restfulApiPort)
+	t.Run("listen default restful api port "+restfulApiPort, func(t *testing.T) {
+		utils.WaitServiceOnline(t, restfulApiPort)
 	})
 }

--- a/test/suites/ekuiper/streams_rules_test.go
+++ b/test/suites/ekuiper/streams_rules_test.go
@@ -16,15 +16,16 @@ const deviceVirtualPort = "59900"
 func TestStreamsAndRules(t *testing.T) {
 
 	t.Cleanup(func() {
-		t.Log("[SUBTEST CLEANUP]")
 		utils.Exec(t,
-			"sudo snap stop --disable edgex-ekuiper.kuiper",
-			"sudo snap set edgexfoundry app-service-configurable=off",
-			"sudo snap set edgexfoundry device-virtual=off")
+			"sudo snap stop edgex-ekuiper.kuiper",
+			"sudo snap stop edgexfoundry.app-service-configurable",
+			"sudo snap stop edgexfoundry.device-virtual")
 	})
 
-	t.Run("create-stream", func(t *testing.T) {
-		t.Log("Test if stream creation works")
+	utils.Exec(t,
+		"sudo snap start edgex-ekuiper.kuiper",
+		"sudo snap start edgexfoundry.app-service-configurable",
+		"sudo snap start edgexfoundry.device-virtual")
 
 	t.Run("create stream", func(t *testing.T) {
 		utils.Exec(t, `edgex-ekuiper.kuiper-cli create stream stream1 '()WITH(FORMAT="JSON",TYPE="edgex")'`)

--- a/test/suites/ekuiper/streams_rules_test.go
+++ b/test/suites/ekuiper/streams_rules_test.go
@@ -13,16 +13,7 @@ import (
 
 const deviceVirtualPort = "59900"
 
-func setupSubtestStreamsAndRules(t *testing.T) {
-	t.Log("[SUBTEST SETUP]")
-	utils.Exec(t,
-		"sudo snap start --enable edgex-ekuiper.kuiper",
-		"sudo snap set edgexfoundry app-service-configurable=on",
-		"sudo snap set edgexfoundry device-virtual=on")
-}
-
-func TestStreamsAndRuels(t *testing.T) {
-	setupSubtestStreamsAndRules(t)
+func TestStreamsAndRules(t *testing.T) {
 
 	t.Cleanup(func() {
 		t.Log("[SUBTEST CLEANUP]")
@@ -35,12 +26,11 @@ func TestStreamsAndRuels(t *testing.T) {
 	t.Run("create-stream", func(t *testing.T) {
 		t.Log("Test if stream creation works")
 
+	t.Run("create stream", func(t *testing.T) {
 		utils.Exec(t, `edgex-ekuiper.kuiper-cli create stream stream1 '()WITH(FORMAT="JSON",TYPE="edgex")'`)
 	})
 
-	t.Run("create-rule-log", func(t *testing.T) {
-		t.Log("Test if rule_log creation works")
-
+	t.Run("create rule_log", func(t *testing.T) {
 		utils.Exec(t,
 			`edgex-ekuiper.kuiper-cli create rule rule_log '
 			{
@@ -53,9 +43,7 @@ func TestStreamsAndRuels(t *testing.T) {
 			}'`)
 	})
 
-	t.Run("create-rule-edgex-message-bus", func(t *testing.T) {
-		t.Log("Test if rule_mqtt creation works")
-
+	t.Run("create rule_edgex_message_bus", func(t *testing.T) {
 		utils.Exec(t,
 			`edgex-ekuiper.kuiper-cli create rule rule_edgex_message_bus '
 			{
@@ -120,13 +108,11 @@ func TestStreamsAndRuels(t *testing.T) {
 		}
 	}
 
-	t.Run("check-rule-log", func(t *testing.T) {
-		t.Log("Test if rule_log is running without errors")
+	t.Run("check rule_log", func(t *testing.T) {
 		utils.Exec(t, `edgex-ekuiper.kuiper-cli getstatus rule rule_log`)
 	})
 
-	t.Run("check-rule-edgex-message-bus", func(t *testing.T) {
-		t.Log("Test if rule_edgex_message_bus is running without errors")
+	t.Run("check rule_edgex_message_bus", func(t *testing.T) {
 		utils.Exec(t, `edgex-ekuiper.kuiper-cli getstatus rule rule_edgex_message_bus`)
 	})
 }

--- a/test/utils/net.go
+++ b/test/utils/net.go
@@ -10,7 +10,7 @@ import (
 )
 
 // WaitServiceOnline dials port(s)to check if the service comes online until it reaches the maximum retry
-func WaitServiceOnline(t *testing.T, ports ...string) error {
+func WaitServiceOnline(t *testing.T, ports ...string) {
 	const dialTimeout = 2 * time.Second
 	const maxRetry = 60
 
@@ -31,12 +31,7 @@ func WaitServiceOnline(t *testing.T, ports ...string) error {
 
 		require.Equal(t, true, serviceIsOnline,
 			"Service timed out, reached max %d retries. Error:\n%v", maxRetry, returnErr)
-		// TODO: check if this is ever called after require.Equal?
-		if t.Failed() {
-			return returnErr
-		}
 	}
-	return nil
 }
 
 // PortConnection checks if the port(s) are in use


### PR DESCRIPTION
This is to simplify networking tests:
- Remove redundant log messages - test names are self explanatory.
- Remove setup/cleanup flags - confusing when used in tests/subtests.
- Use snap start/stop to toggle edgexfoundry services - allows setting them back to original state instead of new key set to "on" and then to "off". Clean state is unset the key, but that won't turn the service off. In general "on"/"off" options are only useful for gadgets to control services or to perform batch toggling such as turning off security and it's related components using a single call.
- Remove return of error from `WaitServiceOnline` test util - error handling inline 