### PR TITLE
Replace eKuiper channel latest/edge with 1/edge

### DIFF
--- a/test/suites/ekuiper/main_test.go
+++ b/test/suites/ekuiper/main_test.go
@@ -11,6 +11,11 @@ const ekuiperSnap = "edgex-ekuiper"
 const ekuiperService = "edgex-ekuiper.kuiper"
 
 func TestMain(m *testing.M) {
+	// edgex-ekuiper's latest/edge channel is currently broken:
+	// https://forum.snapcraft.io/t/snapcraft-release-has-no-effects-for-channel-latest-edge/29069
+	if utils.ServiceChannel == "latest/edge" {
+		utils.ServiceChannel = "1/edge"
+	}
 
 	log.Println("[SETUP]")
 


### PR DESCRIPTION
The [edgex-ekuiper](https://snapcraft.io/edgex-ekuiper)'s latest/edge channel is currently broken:
https://forum.snapcraft.io/t/snapcraft-release-has-no-effects-for-channel-latest-edge/29069

This change temporarily replaces `latest/edge` with `1/edge`, no matter if it is the default or set via an environment variable.