### PR TITLE
Move platform ports to utils

### DIFF
--- a/test/suites/device-modbus/main_test.go
+++ b/test/suites/device-modbus/main_test.go
@@ -10,17 +10,6 @@ import (
 const deviceModbusSnap = "edgex-device-modbus"
 const deviceModbusService = "edgex-device-modbus.device-modbus"
 
-var platformPorts = []string{
-	"59880", // core-data
-	"59881", // core-metadata
-	"59882", // core-command
-	"8000",  // kong
-	"5432",  // kong-database
-	"8200",  // vault
-	"8500",  // consul
-	"6379",  // redis
-}
-
 func TestMain(m *testing.M) {
 
 	log.Println("[SETUP]")
@@ -41,7 +30,7 @@ func TestMain(m *testing.M) {
 	utils.SnapInstallFromStore(nil, "edgexfoundry", utils.PlatformChannel)
 
 	// make sure all services are online before starting the tests
-	utils.WaitServiceOnline(nil, platformPorts...)
+	utils.WaitServiceOnline(nil, utils.PlatformPorts...)
 
 	// for local build, the interface isn't auto-connected.
 	// connect manually regardless

--- a/test/suites/device-snmp/main_test.go
+++ b/test/suites/device-snmp/main_test.go
@@ -10,17 +10,6 @@ import (
 const deviceSnmpSnap = "edgex-device-snmp"
 const deviceSnmpService = "edgex-device-snmp.device-snmp"
 
-var platformPorts = []string{
-	"59880", // core-data
-	"59881", // core-metadata
-	"59882", // core-command
-	"8000",  // kong
-	"5432",  // kong-database
-	"8200",  // vault
-	"8500",  // consul
-	"6379",  // redis
-}
-
 func TestMain(m *testing.M) {
 
 	log.Println("[SETUP]")
@@ -41,7 +30,7 @@ func TestMain(m *testing.M) {
 	utils.SnapInstallFromStore(nil, "edgexfoundry", utils.PlatformChannel)
 
 	// make sure all services are online before starting the tests
-	utils.WaitServiceOnline(nil, platformPorts...)
+	utils.WaitServiceOnline(nil, utils.PlatformPorts...)
 
 	// for local build, the interface isn't auto-connected.
 	// connect manually regardless

--- a/test/utils/net.go
+++ b/test/utils/net.go
@@ -10,6 +10,17 @@ import (
 
 const dialTimeout = 2 * time.Second
 
+var PlatformPorts = []string{
+	"59880", // core-data
+	"59881", // core-metadata
+	"59882", // core-command
+	"8000",  // kong
+	"5432",  // kong-database
+	"8200",  // vault
+	"8500",  // consul
+	"6379",  // redis
+}
+
 // WaitServiceOnline waits for a service to come online by dialing its port(s)
 // up to a maximum number
 func WaitServiceOnline(t *testing.T, ports ...string) {


### PR DESCRIPTION
Moving the ports slice to utils so that it can be used by all tests, including the WIP `edgexfoundry` snap tests.