### PR TITLE
Add `edgex-security=off` ekuiper config option

### DIFF
--- a/.github/workflows/snap-testing.yml
+++ b/.github/workflows/snap-testing.yml
@@ -18,7 +18,6 @@ jobs:
           - name: device-mqtt
 
           - name: ekuiper
-            channel: 1/edge
 
           - name: app-service-configurable
 

--- a/test/suites/ekuiper/main_test.go
+++ b/test/suites/ekuiper/main_test.go
@@ -42,6 +42,7 @@ func TestMain(m *testing.M) {
 	}
 
 	// security off
+	utils.SnapStop(nil, "edgex-ekuiper")
 	utils.SnapSet(nil, "edgexfoundry", "security-secret-store", "off")
 	utils.SnapSet(nil, "edgex-ekuiper", "edgex-security", "off")
 	utils.Exec(nil, "sudo rm /var/snap/edgex-ekuiper/current/edgex-ekuiper/secrets-token.json")

--- a/test/suites/ekuiper/main_test.go
+++ b/test/suites/ekuiper/main_test.go
@@ -40,9 +40,6 @@ func TestMain(m *testing.M) {
 		"edgexfoundry:edgex-secretstore-token",
 		ekuiperSnap+":edgex-secretstore-token",
 	)
-	utils.SnapRestart(nil,
-		ekuiperService,
-	)
 
 	// security on (default)
 	exitCode := m.Run()
@@ -51,11 +48,15 @@ func TestMain(m *testing.M) {
 	}
 
 	// security off
-	utils.Exec(nil, "sudo snap set edgexfoundry security-secret-store=off")
+	utils.SnapSet(nil, "edgexfoundry", "security-secret-store", "off")
+	utils.SnapSet(nil, "edgex-ekuiper", "edgex-security", "off")
 	utils.Exec(nil, "sudo rm /var/snap/edgex-ekuiper/current/edgex-ekuiper/secrets-token.json")
 	utils.SnapDisconnect(nil,
 		"edgexfoundry:edgex-secretstore-token",
 		ekuiperSnap+":edgex-secretstore-token",
+	)
+	utils.SnapStart(nil,
+		ekuiperService,
 	)
 
 	exitCode = m.Run()

--- a/test/suites/ekuiper/main_test.go
+++ b/test/suites/ekuiper/main_test.go
@@ -11,12 +11,6 @@ const ekuiperSnap = "edgex-ekuiper"
 const ekuiperService = "edgex-ekuiper.kuiper"
 
 func TestMain(m *testing.M) {
-	// edgex-ekuiper's latest/edge channel is currently broken:
-	// https://forum.snapcraft.io/t/snapcraft-release-has-no-effects-for-channel-latest-edge/29069
-	if utils.ServiceChannel == "latest/edge" {
-		utils.ServiceChannel = "1/edge"
-	}
-
 	log.Println("[SETUP]")
 
 	// start clean


### PR DESCRIPTION
Testing the new eKuiper option: https://github.com/canonical/edgex-ekuiper-snap/pull/20

Also, removing the channel override since the bad revision has been removed from latest/edge. See https://forum.snapcraft.io/t/snapcraft-release-has-no-effects-for-channel-latest-edge/29069