### PR TITLE
Add apps/config options tests for environment variable injection

### DIFF
--- a/test/suites/device-mqtt/config_test.go
+++ b/test/suites/device-mqtt/config_test.go
@@ -22,15 +22,15 @@ func TestEnvConfig(t *testing.T) {
 		utils.RequirePortAvailable(t, newPort)
 
 		// set env. and validate the new port comes online
-		utils.SnapStart(t, deviceMqttSnap)
 		utils.SnapSet(t, deviceMqttSnap, "env.service.port", newPort)
-		utils.SnapRestart(t, deviceMqttService)
+		utils.SnapStart(t, deviceMqttSnap)
 
 		utils.WaitServiceOnline(t, 60, newPort)
 
 		// unset env. and validate the default port comes online
 		utils.SnapUnset(t, deviceMqttSnap, "env.service.port")
 		utils.SnapRestart(t, deviceMqttService)
+
 		utils.WaitServiceOnline(t, 60, defaultServicePort)
 	})
 }
@@ -54,9 +54,8 @@ func TestAppConfig(t *testing.T) {
 		utils.RequirePortAvailable(t, newPort)
 
 		// set apps. and validate the new port comes online
-		utils.SnapStart(t, deviceMqttSnap)
 		utils.SnapSet(t, deviceMqttSnap, "apps.device-mqtt.config.service.port", newPort)
-		utils.SnapRestart(t, deviceMqttService)
+		utils.SnapStart(t, deviceMqttSnap)
 
 		utils.WaitServiceOnline(t, 60, newPort)
 
@@ -87,9 +86,8 @@ func TestGlobalConfig(t *testing.T) {
 		utils.RequirePortAvailable(t, newPort)
 
 		// set config. and validate the new port comes online
-		utils.SnapStart(t, deviceMqttSnap)
 		utils.SnapSet(t, deviceMqttSnap, "config.service.port", newPort)
-		utils.SnapRestart(t, deviceMqttService)
+		utils.SnapStart(t, deviceMqttSnap)
 
 		utils.WaitServiceOnline(t, 60, newPort)
 
@@ -121,10 +119,9 @@ func TestMixedConfig(t *testing.T) {
 
 		// set apps. and config. with different values,
 		// and validate that app-specific option has been picked up because it has higher precedence
-		utils.SnapStart(t, deviceMqttSnap)
 		utils.SnapSet(t, deviceMqttSnap, "apps.device-mqtt.config.service.port", newAppPort)
 		utils.SnapSet(t, deviceMqttSnap, "config.service.port", newConfigPort)
-		utils.SnapRestart(t, deviceMqttService)
+		utils.SnapStart(t, deviceMqttSnap)
 
 		utils.WaitServiceOnline(t, 60, newAppPort)
 	})

--- a/test/suites/device-mqtt/config_test.go
+++ b/test/suites/device-mqtt/config_test.go
@@ -8,12 +8,13 @@ import (
 // Deprecated
 func TestEnvConfig(t *testing.T) {
 	// start clean
-	utils.SnapStop(t, deviceMqttService)
+	utils.SnapStop(t, deviceMqttSnap)
 
 	t.Run("change service port", func(t *testing.T) {
 		t.Cleanup(func() {
-			utils.SnapStop(t, deviceMqttService)
 			utils.SnapUnset(t, deviceMqttSnap, "env.service.port")
+			utils.SnapUnset(t, deviceMqttSnap, "env")
+			utils.SnapRestart(t, deviceMqttSnap)
 		})
 
 		const newPort = "56789"
@@ -21,12 +22,57 @@ func TestEnvConfig(t *testing.T) {
 		// make sure the port is available before using it
 		utils.RequirePortAvailable(t, newPort)
 
-		utils.SnapSet(t, deviceMqttSnap, "env.service.port", newPort)
 		utils.SnapStart(t, deviceMqttSnap)
+		utils.SnapSet(t, deviceMqttSnap, "env.service.port", newPort)
+		utils.SnapRestart(t, deviceMqttSnap)
+
 		utils.WaitServiceOnline(t, 60, newPort)
 	})
 }
 
 func TestAppConfig(t *testing.T) {
-	t.Skip("TODO")
+	// start clean
+	utils.SnapStop(t, deviceMqttSnap)
+
+	t.Run("use apps. and config. for the same option", func(t *testing.T) {
+		t.Cleanup(func() {
+			utils.SnapUnset(t, deviceMqttSnap, "apps.device-mqtt.config.service.port")
+			utils.SnapUnset(t, deviceMqttSnap, "config.service.port")
+			utils.SnapRestart(t, deviceMqttSnap)
+		})
+
+		const newPort = "8888"
+
+		// make sure the port is available before using it
+		utils.RequirePortAvailable(t, newPort)
+
+		utils.SnapStart(t, deviceMqttSnap)
+		utils.SnapSet(t, deviceMqttSnap, "apps.device-mqtt.config.service.port", newPort)
+		utils.SnapSet(t, deviceMqttSnap, "config.service.port", newPort)
+		utils.SnapRestart(t, deviceMqttSnap)
+
+		utils.WaitServiceOnline(t, 60, newPort)
+	})
+
+	t.Run("use apps. and config. for different options", func(t *testing.T) {
+		t.Cleanup(func() {
+			utils.SnapUnset(t, deviceMqttSnap, "apps.device-mqtt.config.service.port")
+			utils.SnapUnset(t, deviceMqttSnap, "config.service.port")
+			utils.SnapRestart(t, deviceMqttSnap)
+		})
+
+		const newAppPort = "11111"
+		const newConfigPort = "22222"
+
+		// make sure the ports are available before using it
+		utils.RequirePortAvailable(t, newAppPort)
+		utils.RequirePortAvailable(t, newConfigPort)
+
+		utils.SnapStart(t, deviceMqttSnap)
+		utils.SnapSet(t, deviceMqttSnap, "apps.device-mqtt.config.service.port", newAppPort)
+		utils.SnapSet(t, deviceMqttSnap, "config.service.port", newConfigPort)
+		utils.SnapRestart(t, deviceMqttSnap)
+
+		utils.WaitServiceOnline(t, 60, newAppPort)
+	})
 }

--- a/test/suites/device-mqtt/config_test.go
+++ b/test/suites/device-mqtt/config_test.go
@@ -12,9 +12,7 @@ func TestEnvConfig(t *testing.T) {
 
 	t.Run("change service port", func(t *testing.T) {
 		t.Cleanup(func() {
-			utils.SnapUnset(t, deviceMqttSnap, "env.service.port")
-			utils.SnapUnset(t, deviceMqttSnap, "env")
-			utils.SnapRestart(t, deviceMqttSnap)
+			utils.SnapStop(t, deviceMqttSnap)
 		})
 
 		const newPort = "56789"
@@ -22,11 +20,18 @@ func TestEnvConfig(t *testing.T) {
 		// make sure the port is available before using it
 		utils.RequirePortAvailable(t, newPort)
 
+		// set env. and validate the new port comes online
 		utils.SnapStart(t, deviceMqttSnap)
 		utils.SnapSet(t, deviceMqttSnap, "env.service.port", newPort)
-		utils.SnapRestart(t, deviceMqttSnap)
+		utils.SnapRestart(t, deviceMqttService)
 
 		utils.WaitServiceOnline(t, 60, newPort)
+
+		// unset env. and validate the default port comes online
+		utils.SnapUnset(t, deviceMqttSnap, "env.service.port")
+		utils.SnapUnset(t, deviceMqttSnap, "env")
+		utils.SnapRestart(t, deviceMqttService)
+		utils.WaitServiceOnline(t, 60, defaultServicePort)
 	})
 }
 
@@ -34,22 +39,86 @@ func TestAppConfig(t *testing.T) {
 	// start clean
 	utils.SnapStop(t, deviceMqttSnap)
 
-	t.Run("use apps. and config. for the same option", func(t *testing.T) {
+	t.Run("set and unset apps.", func(t *testing.T) {
 		t.Cleanup(func() {
-			utils.SnapUnset(t, deviceMqttSnap, "apps.device-mqtt.config.service.port")
-			utils.SnapUnset(t, deviceMqttSnap, "config.service.port")
-			utils.SnapRestart(t, deviceMqttSnap)
+			utils.SnapStop(t, deviceMqttSnap)
 		})
 
-		const newPort = "8888"
+		const newPort = "1111"
 
 		// make sure the port is available before using it
 		utils.RequirePortAvailable(t, newPort)
 
+		// set apps. and validate the new port comes online
+		utils.SnapStart(t, deviceMqttSnap)
+		utils.SnapSet(t, deviceMqttSnap, "apps.device-mqtt.config.service.port", newPort)
+		utils.SnapRestart(t, deviceMqttService)
+
+		utils.WaitServiceOnline(t, 60, newPort)
+
+		// unset apps. and validate the default port comes online
+		utils.SnapUnset(t, deviceMqttSnap, "apps.device-mqtt.config.service.port")
+		utils.SnapUnset(t, deviceMqttSnap, "config.service.port")
+		utils.SnapRestart(t, deviceMqttService)
+
+		utils.WaitServiceOnline(t, 60, defaultServicePort)
+	})
+}
+
+func TestGlobalConfig(t *testing.T) {
+	// start clean
+	utils.SnapStop(t, deviceMqttSnap)
+
+	t.Run("set and unset apps.", func(t *testing.T) {
+		t.Cleanup(func() {
+			utils.SnapStop(t, deviceMqttSnap)
+		})
+
+		const newPort = "2222"
+
+		// make sure the port is available before using it
+		utils.RequirePortAvailable(t, newPort)
+
+		// set config. and validate the new port comes online
+		utils.SnapStart(t, deviceMqttSnap)
+		utils.SnapSet(t, deviceMqttSnap, "config.service.port", newPort)
+		utils.SnapRestart(t, deviceMqttService)
+
+		utils.WaitServiceOnline(t, 60, newPort)
+
+		// unset config. and validate the default port comes online
+		utils.SnapUnset(t, deviceMqttSnap, "config.service.port")
+		utils.SnapRestart(t, deviceMqttService)
+
+		utils.WaitServiceOnline(t, 60, defaultServicePort)
+	})
+}
+
+func TestAppGlobalConfig(t *testing.T) {
+	// start clean
+	utils.SnapStop(t, deviceMqttSnap)
+
+	t.Run("use apps. and config. for the same option", func(t *testing.T) {
+		t.Cleanup(func() {
+			utils.SnapUnset(t, deviceMqttSnap, "apps.device-mqtt.config.service.port")
+			utils.SnapUnset(t, deviceMqttSnap, "config.service.port")
+			utils.SnapRestart(t, deviceMqttService)
+			utils.WaitServiceOnline(t, 60, defaultServicePort)
+
+			utils.SnapStop(t, deviceMqttSnap)
+		})
+
+		const newPort = "33333"
+
+		// make sure the port is available before using it
+		utils.RequirePortAvailable(t, newPort)
+
+		// set apps. and config. with the same option,
+		// and validate that option has been picked upp by the service
 		utils.SnapStart(t, deviceMqttSnap)
 		utils.SnapSet(t, deviceMqttSnap, "apps.device-mqtt.config.service.port", newPort)
 		utils.SnapSet(t, deviceMqttSnap, "config.service.port", newPort)
-		utils.SnapRestart(t, deviceMqttSnap)
+		utils.SnapRestart(t, deviceMqttService)
 
 		utils.WaitServiceOnline(t, 60, newPort)
 	})
@@ -58,20 +127,22 @@ func TestAppConfig(t *testing.T) {
 		t.Cleanup(func() {
 			utils.SnapUnset(t, deviceMqttSnap, "apps.device-mqtt.config.service.port")
 			utils.SnapUnset(t, deviceMqttSnap, "config.service.port")
-			utils.SnapRestart(t, deviceMqttSnap)
+			utils.SnapRestart(t, deviceMqttService)
 		})
 
-		const newAppPort = "11111"
-		const newConfigPort = "22222"
+		const newAppPort = "44444"
+		const newConfigPort = "55555"
 
 		// make sure the ports are available before using it
 		utils.RequirePortAvailable(t, newAppPort)
 		utils.RequirePortAvailable(t, newConfigPort)
 
+		// set apps. and config. with different options,
+		// and validate that app-specific option has been picked up with higher precedence
 		utils.SnapStart(t, deviceMqttSnap)
 		utils.SnapSet(t, deviceMqttSnap, "apps.device-mqtt.config.service.port", newAppPort)
 		utils.SnapSet(t, deviceMqttSnap, "config.service.port", newConfigPort)
-		utils.SnapRestart(t, deviceMqttSnap)
+		utils.SnapRestart(t, deviceMqttService)
 
 		utils.WaitServiceOnline(t, 60, newAppPort)
 	})

--- a/test/suites/device-rest/config_test.go
+++ b/test/suites/device-rest/config_test.go
@@ -22,9 +22,8 @@ func TestEnvConfig(t *testing.T) {
 		utils.RequirePortAvailable(t, newPort)
 
 		// set env. and validate the new port comes online
-		utils.SnapStart(t, deviceRestSnap)
 		utils.SnapSet(t, deviceRestSnap, "env.service.port", newPort)
-		utils.SnapRestart(t, deviceRestService)
+		utils.SnapStart(t, deviceRestSnap)
 
 		utils.WaitServiceOnline(t, 60, newPort)
 
@@ -54,9 +53,8 @@ func TestAppConfig(t *testing.T) {
 		utils.RequirePortAvailable(t, newPort)
 
 		// set apps. and validate the new port comes online
-		utils.SnapStart(t, deviceRestSnap)
 		utils.SnapSet(t, deviceRestSnap, "apps.device-rest.config.service.port", newPort)
-		utils.SnapRestart(t, deviceRestService)
+		utils.SnapStart(t, deviceRestSnap)
 
 		utils.WaitServiceOnline(t, 60, newPort)
 
@@ -87,9 +85,8 @@ func TestGlobalConfig(t *testing.T) {
 		utils.RequirePortAvailable(t, newPort)
 
 		// set config. and validate the new port comes online
-		utils.SnapStart(t, deviceRestSnap)
 		utils.SnapSet(t, deviceRestSnap, "config.service.port", newPort)
-		utils.SnapRestart(t, deviceRestService)
+		utils.SnapStart(t, deviceRestSnap)
 
 		utils.WaitServiceOnline(t, 60, newPort)
 
@@ -121,10 +118,9 @@ func TestMixedConfig(t *testing.T) {
 
 		// set apps. and config. with different values,
 		// and validate that app-specific option has been picked up because it has higher precedence
-		utils.SnapStart(t, deviceRestSnap)
 		utils.SnapSet(t, deviceRestSnap, "apps.device-rest.config.service.port", newAppPort)
 		utils.SnapSet(t, deviceRestSnap, "config.service.port", newConfigPort)
-		utils.SnapRestart(t, deviceRestService)
+		utils.SnapStart(t, deviceRestSnap)
 
 		utils.WaitServiceOnline(t, 60, newAppPort)
 	})

--- a/test/suites/device-rest/config_test.go
+++ b/test/suites/device-rest/config_test.go
@@ -7,25 +7,125 @@ import (
 
 // Deprecated
 func TestEnvConfig(t *testing.T) {
+	// start clean
+	utils.SnapStop(t, deviceRestSnap)
 
 	t.Run("change service port", func(t *testing.T) {
 		t.Cleanup(func() {
-			utils.SnapStop(t, deviceRestService)
-			utils.SnapUnset(t, deviceRestSnap, "env.service.port")
+			utils.SnapUnset(t, deviceRestSnap, "env")
+			utils.SnapStop(t, deviceRestSnap)
 		})
 
-		const newPort = "56789"
+		const newPort = "11111"
 
 		// make sure the port is available before using it
 		utils.RequirePortAvailable(t, newPort)
 
-		utils.SnapStop(t, deviceRestSnap)
-		utils.SnapSet(t, deviceRestSnap, "env.service.port", newPort)
+		// set env. and validate the new port comes online
 		utils.SnapStart(t, deviceRestSnap)
+		utils.SnapSet(t, deviceRestSnap, "env.service.port", newPort)
+		utils.SnapRestart(t, deviceRestService)
+
 		utils.WaitServiceOnline(t, 60, newPort)
+
+		// unset env. and validate the default port comes online
+		utils.SnapUnset(t, deviceRestSnap, "env.service.port")
+		utils.SnapRestart(t, deviceRestService)
+		utils.WaitServiceOnline(t, 60, defaultServicePort)
 	})
 }
 
 func TestAppConfig(t *testing.T) {
-	t.Skip("TODO")
+	// start clean
+	utils.SnapStop(t, deviceRestSnap)
+
+	t.Run("set and unset apps.", func(t *testing.T) {
+		t.Cleanup(func() {
+			// temporary using unset apps and unset config together here to do unset apps' job
+			// until this issue been solved: https://github.com/canonical/edgex-snap-hooks/issues/43
+			utils.SnapUnset(t, deviceRestSnap, "apps.device-rest.config.service.port")
+			utils.SnapUnset(t, deviceRestSnap, "config.service.port")
+			utils.SnapStop(t, deviceRestSnap)
+		})
+
+		const newPort = "22222"
+
+		// make sure the port is available before using it
+		utils.RequirePortAvailable(t, newPort)
+
+		// set apps. and validate the new port comes online
+		utils.SnapStart(t, deviceRestSnap)
+		utils.SnapSet(t, deviceRestSnap, "apps.device-rest.config.service.port", newPort)
+		utils.SnapRestart(t, deviceRestService)
+
+		utils.WaitServiceOnline(t, 60, newPort)
+
+		// unset apps. and validate the default port comes online
+		// temporary using unset apps and unset config together here to do unset apps' job
+		// until this issue been solved: https://github.com/canonical/edgex-snap-hooks/issues/43
+		utils.SnapUnset(t, deviceRestSnap, "apps.device-rest.config.service.port")
+		utils.SnapUnset(t, deviceRestSnap, "config.service.port")
+		utils.SnapRestart(t, deviceRestService)
+
+		utils.WaitServiceOnline(t, 60, defaultServicePort)
+	})
+}
+
+func TestGlobalConfig(t *testing.T) {
+	// start clean
+	utils.SnapStop(t, deviceRestSnap)
+
+	t.Run("set and unset apps.", func(t *testing.T) {
+		t.Cleanup(func() {
+			utils.SnapUnset(t, deviceRestSnap, "config.service.port")
+			utils.SnapStop(t, deviceRestSnap)
+		})
+
+		const newPort = "33333"
+
+		// make sure the port is available before using it
+		utils.RequirePortAvailable(t, newPort)
+
+		// set config. and validate the new port comes online
+		utils.SnapStart(t, deviceRestSnap)
+		utils.SnapSet(t, deviceRestSnap, "config.service.port", newPort)
+		utils.SnapRestart(t, deviceRestService)
+
+		utils.WaitServiceOnline(t, 60, newPort)
+
+		// unset config. and validate the default port comes online
+		utils.SnapUnset(t, deviceRestSnap, "config.service.port")
+		utils.SnapRestart(t, deviceRestService)
+
+		utils.WaitServiceOnline(t, 60, defaultServicePort)
+	})
+}
+
+func TestMixedConfig(t *testing.T) {
+	// start clean
+	utils.SnapStop(t, deviceRestSnap)
+
+	t.Run("use apps. and config. for different values", func(t *testing.T) {
+		t.Cleanup(func() {
+			utils.SnapUnset(t, deviceRestSnap, "apps.device-rest.config.service.port")
+			utils.SnapUnset(t, deviceRestSnap, "config.service.port")
+			utils.SnapStop(t, deviceRestService)
+		})
+
+		const newAppPort = "44444"
+		const newConfigPort = "55555"
+
+		// make sure the ports are available before using it
+		utils.RequirePortAvailable(t, newAppPort)
+		utils.RequirePortAvailable(t, newConfigPort)
+
+		// set apps. and config. with different values,
+		// and validate that app-specific option has been picked up because it has higher precedence
+		utils.SnapStart(t, deviceRestSnap)
+		utils.SnapSet(t, deviceRestSnap, "apps.device-rest.config.service.port", newAppPort)
+		utils.SnapSet(t, deviceRestSnap, "config.service.port", newConfigPort)
+		utils.SnapRestart(t, deviceRestService)
+
+		utils.WaitServiceOnline(t, 60, newAppPort)
+	})
 }


### PR DESCRIPTION
This device-mqtt test will pass using the new version of device-mqtt snap with new env vars injection implementation: https://github.com/edgexfoundry/device-mqtt-go/pull/365

These two PRs are blocking each other.