### PR TITLE
Add config tests for app-rfid-llrp-inventory

### DIFF
--- a/.github/workflows/snap-testing.yml
+++ b/.github/workflows/snap-testing.yml
@@ -43,6 +43,7 @@ jobs:
           - name: device-rfid-llrp
           
           - name: app-rfid-llrp-inventory
+            channel: edge/pr-74
 
           
     # use local action to test

--- a/test/suites/app-rfid-llrp-inventory/config_test.go
+++ b/test/suites/app-rfid-llrp-inventory/config_test.go
@@ -7,25 +7,18 @@ import (
 
 // Deprecated
 func TestEnvConfig(t *testing.T) {
-
-	t.Run("change service port", func(t *testing.T) {
-		t.Cleanup(func() {
-			utils.SnapStop(t, appRfidLlrpService)
-			utils.SnapUnset(t, appRfidLlrpSnap, "env.service.port")
-		})
-
-		const newPort = "56789"
-
-		// make sure the port is available before using it
-		utils.RequirePortAvailable(t, newPort)
-
-		utils.SnapStop(t, appRfidLlrpSnap)
-		utils.SnapSet(t, appRfidLlrpSnap, "env.service.port", newPort)
-		utils.SnapStart(t, appRfidLlrpSnap)
-		utils.WaitServiceOnline(t, 60, newPort)
-	})
+	utils.SetEnvConfig(t, appRfidLlrpSnap, appRfidLlrpService, defaultServicePort)
 }
 
 func TestAppConfig(t *testing.T) {
-	t.Skip("TODO")
+	utils.SetAppConfig(t, appRfidLlrpSnap, appRfidLlrpService, appName, defaultServicePort)
+}
+
+func TestGlobalConfig(t *testing.T) {
+	// start clean
+	utils.SetGlobalConfig(t, appRfidLlrpSnap, appRfidLlrpService, defaultServicePort)
+}
+
+func TestMixedConfig(t *testing.T) {
+	utils.SetMixedConfig(t, appRfidLlrpSnap, appRfidLlrpService, appName, defaultServicePort)
 }

--- a/test/suites/app-rfid-llrp-inventory/main_test.go
+++ b/test/suites/app-rfid-llrp-inventory/main_test.go
@@ -8,8 +8,11 @@ import (
 	"time"
 )
 
-const appRfidLlrpSnap = "edgex-app-rfid-llrp-inventory"
-const appRfidLlrpService = "edgex-app-rfid-llrp-inventory.app-rfid-llrp-inventory"
+const (
+	appRfidLlrpSnap    = "edgex-app-rfid-llrp-inventory"
+	appName            = "app-rfid-llrp-inventory"
+	appRfidLlrpService = appRfidLlrpSnap + "." + appName
+)
 
 var start = time.Now()
 


### PR DESCRIPTION
Test locally:
```
FULL_CONFIG_TEST=true SERVICE_CHANNEL=edge/pr-74 go test -p 1 ./test/suites/app-rfid-llrp-inventory
```