### PR TITLE
Remove redundant `app-options` enabling

### DIFF
--- a/test/suites/ekuiper/main_test.go
+++ b/test/suites/ekuiper/main_test.go
@@ -61,7 +61,6 @@ func TestMain(m *testing.M) {
 	utils.SnapStop(nil, "edgex-ekuiper")
 	utils.SnapSet(nil, "edgexfoundry", "security-secret-store", "off")
 	utils.SnapSet(nil, "edgex-ekuiper", "edgex-security", "off")
-	utils.SnapSet(nil, "edgex-device-virtual", "app-options", "true")
 	utils.SnapSet(nil, "edgex-device-virtual", "config.edgex-security-secret-store", "false")
 	utils.Exec(nil, "sudo rm /var/snap/edgex-ekuiper/current/edgex-ekuiper/secrets-token.json")
 


### PR DESCRIPTION
This PR solves https://github.com/canonical/edgex-snap-testing/issues/65