### PR TITLE
Refactor proxy tests

### DIFF
--- a/test/suites/edgexfoundry/proxy_test.go
+++ b/test/suites/edgexfoundry/proxy_test.go
@@ -44,10 +44,9 @@ func TestAddProxyUser(t *testing.T) {
 	// Use secrets-config to add a user example with id 1000
 	stdout, _ := utils.Exec(t,
 		fmt.Sprintf("edgexfoundry.secrets-config proxy adduser --token-type jwt --user example --algorithm ES256 --public_key %s --id 1000 -jwt %s",
-			publicKey,
-			kongAdminJWT))
+			publicKey, kongAdminJWT))
 	// On success, the above command prints the user id
-	require.Equal(t, "1000\n", stdout)
+	require.Equal(t, "1000", strings.TrimSpace(stdout))
 
 	// Generate a JWT token for the above example user
 	jwt, _ := utils.Exec(t,
@@ -93,47 +92,56 @@ func TestTLSCert(t *testing.T) {
 
 	// Add the certificate, using Kong Admin JWT to authenticate
 	caCertFile, caKeyFile := generateCerts(tmpDir)
-	utils.Exec(t, fmt.Sprintf("edgexfoundry.secrets-config proxy tls --incert %s --inkey %s --admin_api_jwt %s", caCertFile, caKeyFile, kongAdminJWT))
+	utils.Exec(t, fmt.Sprintf("edgexfoundry.secrets-config proxy tls --incert %s --inkey %s --admin_api_jwt %s",
+		caCertFile, caKeyFile, kongAdminJWT))
 
-	// Wait the certificate to be fully installed
-	caKey, err := os.ReadFile(caKeyFile)
-	require.NoError(t, err)
-	waitCertInstall(t, string(caKey), 10)
+	// Wait for the certificate to be fully installed
+	waitCertInstall(t, caKeyFile, 10)
 
-	// Check if TLS is setup correctly returning status code 401
-	code, _ := utils.Exec(t, fmt.Sprintf(`curl --show-error --silent --include --output /dev/null --write-out "%%{http_code}" --cacert %s -X GET 'https://localhost:8443/core-data/api/v2/ping' -H "Authorization: Bearer %s"`, caCertFile, "testToken"))
-	require.Equal(t, "401\n", code)
+	// Check if TLS is setup correctly
+	// A success response should return status 401 because the endpoint is protected.
+	// Note: %%	is a literal percent sign
+	code, _ := utils.Exec(t, fmt.Sprintf("curl --show-error --silent --include --output /dev/null --write-out '%%{http_code}' --cacert %s -X GET 'https://localhost:8443/core-data/api/v2/ping'",
+		caCertFile))
+	require.Equal(t, "401", strings.TrimSpace(code))
 }
 
 // generateCerts generates CA private key, CA cert,
 // server private key, server signing request, server cert
-func generateCerts(tmpDir string) (string, string) {
+func generateCerts(dir string) (string, string) {
 	var (
-		caKeyFile      = tmpDir + "/ca.key"
-		caCertFile     = tmpDir + "/ca.crt"
-		serverCsrFile  = tmpDir + "/server.csr"
-		serverKeyFile  = tmpDir + "/server.key"
-		serverCertFile = tmpDir + "/server.crt"
+		caKeyFile      = dir + "/ca.key"
+		caCertFile     = dir + "/ca.crt"
+		serverCsrFile  = dir + "/server.csr"
+		serverKeyFile  = dir + "/server.key"
+		serverCertFile = dir + "/server.crt"
 	)
 
 	// Generate the Certificate Authority (CA) Private Key
-	utils.Exec(nil, fmt.Sprintf("openssl ecparam -name prime256v1 -genkey -noout -out %s", caKeyFile))
+	utils.Exec(nil, fmt.Sprintf("openssl ecparam -name prime256v1 -genkey -noout -out %s",
+		caKeyFile))
 	// Generate the Certificate Authority Certificate
-	utils.Exec(nil, fmt.Sprintf(`openssl req -new -x509 -sha256 -key %s -out %s -subj "/CN=localhost"`, caKeyFile, caCertFile))
+	utils.Exec(nil, fmt.Sprintf("openssl req -new -x509 -sha256 -key %s -out %s -subj '/CN=localhost'",
+		caKeyFile, caCertFile))
 
 	// Generate the Server Certificate Private Keys
-	utils.Exec(nil, fmt.Sprintf("openssl ecparam -name prime256v1 -genkey -noout -out %s", serverKeyFile))
+	utils.Exec(nil, fmt.Sprintf("openssl ecparam -name prime256v1 -genkey -noout -out %s",
+		serverKeyFile))
 	// Generate the Server Certificate Signing Request
-	utils.Exec(nil, fmt.Sprintf(`openssl req -new -sha256 -key %s -out %s -subj "/CN=localhost"`, serverKeyFile, serverCsrFile))
+	utils.Exec(nil, fmt.Sprintf("openssl req -new -sha256 -key %s -out %s -subj '/CN=localhost'",
+		serverKeyFile, serverCsrFile))
 	// Generate the Server Certificate
-	utils.Exec(nil, fmt.Sprintf(`openssl x509 -req -in %s -CA %s -CAkey %s -CAcreateserial -out %s -days 1000 -sha256`, serverCsrFile, caCertFile, caKeyFile, serverCertFile))
+	utils.Exec(nil, fmt.Sprintf("openssl x509 -req -in %s -CA %s -CAkey %s -CAcreateserial -out %s -days 1000 -sha256",
+		serverCsrFile, caCertFile, caKeyFile, serverCertFile))
 
 	return caCertFile, caKeyFile
 }
 
 // waitCertInstall checks if certificate is fully installed
 // up to a maximum retry number
-func waitCertInstall(t *testing.T, caKey string, maxRetry int) {
+func waitCertInstall(t *testing.T, caKeyFile string, maxRetry int) {
+	caKey, err := os.ReadFile(caKeyFile)
+	require.NoError(t, err)
 
 	type ResponseBody struct {
 		Data []struct {
@@ -163,5 +171,5 @@ func waitCertInstall(t *testing.T, caKey string, maxRetry int) {
 		}
 	}
 
-	require.Equal(t, res.Data[0].Key, caKey)
+	require.Equal(t, res.Data[0].Key, string(caKey))
 }


### PR DESCRIPTION
- Remove obsolete wrong Authorization token from protected endpoint call.
- Using double-quotes for string formatting. Back quotes should only be used when double-quotes have to be in the string or when using multi-line strings.
- Moved cert file read to function where the result is used.
- Clean stdouts before assertions by removing the end lines.
- Format long lines to improve readability
- Rename input function arg from tmpDir to dir since the function doesn't care if this is temp or any other directory.
- Improve comments
- Add delay to allow certificate use by the proxy (see https://github.com/canonical/edgex-snap-testing/pull/73#issuecomment-1172482838)
- Return all paths from cert generator function to allow better reusability
- Improve logging
