### PR TITLE
Reorder tests to avoid Kong error when setting a certificate after adding a user

### DIFF
--- a/test/suites/edgexfoundry/proxy_test.go
+++ b/test/suites/edgexfoundry/proxy_test.go
@@ -22,7 +22,7 @@ func TestTLSCert(t *testing.T) {
 		utils.SnapUnset(t, platformSnap, "app-options")
 	})
 
-	t.Logf("Generate CA and self-signed certificates")
+	t.Logf("Generate CA and server certificates")
 	_, caCertFile, _, serverKeyFile, serverCertFile := generateCerts(t)
 
 	serverKey, err := os.ReadFile(serverKeyFile)

--- a/test/suites/edgexfoundry/proxy_test.go
+++ b/test/suites/edgexfoundry/proxy_test.go
@@ -14,56 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Test seeding an admin user using snap options
-// https://docs.edgexfoundry.org/2.2/getting-started/Ch-GettingStartedSnapUsers/#adding-api-gateway-users
-func TestAddProxyUser(t *testing.T) {
-	const (
-		tmpDir         = "./tmp"
-		publicKeyFile  = tmpDir + "/public.pem"
-		privateKeyFile = tmpDir + "/private.pem"
-	)
-
-	// start clean
-	require.NoError(t, os.RemoveAll(tmpDir))
-
-	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(tmpDir))
-		utils.SnapUnset(t, platformSnap, "apps")
-		utils.SnapUnset(t, platformSnap, "app-options")
-	})
-
-	t.Log("Generate private and public keys")
-	require.NoError(t, os.Mkdir(tmpDir, 0755))
-	utils.Exec(t, fmt.Sprintf("openssl ecparam -genkey -name prime256v1 -noout -out %s", privateKeyFile))
-	utils.Exec(t, fmt.Sprintf("openssl ec -in %s -pubout -out %s", privateKeyFile, publicKeyFile))
-
-	t.Log("Add the public key for admin user")
-	publicKey, err := os.ReadFile(publicKeyFile)
-	require.NoError(t, err)
-
-	utils.SnapSet(t, platformSnap, "app-options", "true")
-	utils.SnapSet(t, platformSnap, "apps.secrets-config.proxy.admin.public-key", string(publicKey))
-
-	t.Log("Generate a JWT token for the admin user")
-	// The seedable "admin" has id 1
-	jwt, _ := utils.Exec(t,
-		fmt.Sprintf("edgexfoundry.secrets-config proxy jwt --algorithm ES256 --private_key %s --id 1 --expiration=1h", privateKeyFile))
-
-	t.Log("Call an API on behalf of admin user")
-	req, err := http.NewRequest(http.MethodGet, "https://localhost:8443/core-data/api/v2/ping", nil)
-	require.NoError(t, err)
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", strings.TrimSpace(jwt)))
-
-	// InsecureSkipVerify because the proxy uses the built-in self-signed certificate
-	client := http.Client{Transport: &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	}}
-	resp, err := client.Do(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-	require.Equal(t, 200, resp.StatusCode)
-}
-
 // Test seeding a custom TLS certificate using snap options
 // https://docs.edgexfoundry.org/2.2/getting-started/Ch-GettingStartedSnapUsers/#changing-tls-certificates
 func TestTLSCert(t *testing.T) {
@@ -72,7 +22,7 @@ func TestTLSCert(t *testing.T) {
 		utils.SnapUnset(t, platformSnap, "app-options")
 	})
 
-	t.Logf("Generate a self-signed certificate")
+	t.Logf("Generate CA and self-signed certificates")
 	_, caCertFile, _, serverKeyFile, serverCertFile := generateCerts(t)
 
 	serverKey, err := os.ReadFile(serverKeyFile)
@@ -112,6 +62,44 @@ func TestTLSCert(t *testing.T) {
 	require.Equal(t, "401", strings.TrimSpace(code))
 }
 
+// Test seeding an admin user using snap options
+// https://docs.edgexfoundry.org/2.2/getting-started/Ch-GettingStartedSnapUsers/#adding-api-gateway-users
+func TestAddProxyUser(t *testing.T) {
+	t.Cleanup(func() {
+		utils.SnapUnset(t, platformSnap, "apps")
+		utils.SnapUnset(t, platformSnap, "app-options")
+	})
+
+	t.Log("Generate private and public keys")
+	publicKeyFile, privateKeyFile := generateKeyPair(t)
+
+	t.Log("Add the public key for admin user")
+	publicKey, err := os.ReadFile(publicKeyFile)
+	require.NoError(t, err)
+
+	utils.SnapSet(t, platformSnap, "app-options", "true")
+	utils.SnapSet(t, platformSnap, "apps.secrets-config.proxy.admin.public-key", string(publicKey))
+
+	t.Log("Generate a JWT token for the admin user")
+	// The seedable "admin" has id 1
+	jwt, _ := utils.Exec(t,
+		fmt.Sprintf("edgexfoundry.secrets-config proxy jwt --algorithm ES256 --private_key %s --id 1 --expiration=1h", privateKeyFile))
+
+	t.Log("Call an API on behalf of admin user")
+	req, err := http.NewRequest(http.MethodGet, "https://localhost:8443/core-data/api/v2/ping", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", strings.TrimSpace(jwt)))
+
+	// InsecureSkipVerify because the proxy uses the built-in self-signed certificate
+	client := http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, 200, resp.StatusCode)
+}
+
 // generateCerts generates CA private key, CA cert,
 // server private key, server signing request, server cert
 func generateCerts(t *testing.T) (caKeyFile, caCertFile, serverCsrFile, serverKeyFile, serverCertFile string) {
@@ -149,6 +137,27 @@ func generateCerts(t *testing.T) (caKeyFile, caCertFile, serverCsrFile, serverKe
 	// Generate the Server Certificate
 	utils.Exec(nil, fmt.Sprintf("openssl x509 -req -in %s -CA %s -CAkey %s -CAcreateserial -out %s -days 1 -sha256",
 		serverCsrFile, caCertFile, caKeyFile, serverCertFile))
+
+	return
+}
+
+func generateKeyPair(t *testing.T) (publicKeyFile, privateKeyFile string) {
+	const tmpDir = "./tmp"
+
+	// start clean
+	require.NoError(t, os.RemoveAll(tmpDir))
+
+	t.Cleanup(func() {
+		require.NoError(t, os.RemoveAll(tmpDir))
+	})
+
+	publicKeyFile = tmpDir + "/public.pem"
+	privateKeyFile = tmpDir + "/private.pem"
+
+	require.NoError(t, os.Mkdir(tmpDir, 0755))
+
+	utils.Exec(t, fmt.Sprintf("openssl ecparam -genkey -name prime256v1 -noout -out %s", privateKeyFile))
+	utils.Exec(t, fmt.Sprintf("openssl ec -in %s -pubout -out %s", privateKeyFile, publicKeyFile))
 
 	return
 }


### PR DESCRIPTION
Related to #83

This is a temporary fix to make the tests stable until we find out the source of the issue.