### PR TITLE
Add option to execute command without printing standard output/error

### DIFF
--- a/test/utils/exec.go
+++ b/test/utils/exec.go
@@ -7,8 +7,12 @@ import (
 	"testing"
 )
 
-// Exec executes a command
 func Exec(t *testing.T, command string) (stdout, stderr string) {
+	return exec(t, command, false)
+}
+
+// exec executes a command
+func exec(t *testing.T, command string, verbose bool) (stdout, stderr string) {
 	logf(t, "[exec] %s", command)
 
 	cmd := exec.Command("/bin/sh", "-c", command)
@@ -27,7 +31,9 @@ func Exec(t *testing.T, command string) (stdout, stderr string) {
 	go func() {
 		for outScanner.Scan() {
 			line := outScanner.Text()
-			logf(t, "[stdout] %s", line)
+			if verbose {
+				logf(t, "[stdout] %s", line)
+			}
 			stdout += line + "\n"
 		}
 		if err := outScanner.Err(); err != nil {
@@ -48,7 +54,9 @@ func Exec(t *testing.T, command string) (stdout, stderr string) {
 	go func() {
 		for errScanner.Scan() {
 			line := errScanner.Text()
-			logf(t, "[stderr] %s", line)
+			if verbose {
+				logf(t, "[stderr] %s", line)
+			}
 			stderr += line + "\n"
 		}
 		if err := errScanner.Err(); err != nil {

--- a/test/utils/exec.go
+++ b/test/utils/exec.go
@@ -8,11 +8,11 @@ import (
 )
 
 func Exec(t *testing.T, command string) (stdout, stderr string) {
-	return exec(t, command, false)
+	return execVerbose(t, command, false)
 }
 
-// exec executes a command
-func exec(t *testing.T, command string, verbose bool) (stdout, stderr string) {
+// execVerbose executes a command
+func execVerbose(t *testing.T, command string, verbose bool) (stdout, stderr string) {
 	logf(t, "[exec] %s", command)
 
 	cmd := exec.Command("/bin/sh", "-c", command)

--- a/test/utils/exec.go
+++ b/test/utils/exec.go
@@ -2,20 +2,20 @@ package utils
 
 import (
 	"bufio"
-	"os/exec"
+	goexec "os/exec"
 	"sync"
 	"testing"
 )
 
 func Exec(t *testing.T, command string) (stdout, stderr string) {
-	return execVerbose(t, command, false)
+	return exec(t, command, false)
 }
 
-// execVerbose executes a command
-func execVerbose(t *testing.T, command string, verbose bool) (stdout, stderr string) {
+// exec executes a command
+func exec(t *testing.T, command string, verbose bool) (stdout, stderr string) {
 	logf(t, "[exec] %s", command)
 
-	cmd := exec.Command("/bin/sh", "-c", command)
+	cmd := goexec.Command("/bin/sh", "-c", command)
 
 	var wg sync.WaitGroup
 

--- a/test/utils/snap.go
+++ b/test/utils/snap.go
@@ -87,7 +87,7 @@ func SnapDumpLogs(t *testing.T, start time.Time, name string) {
 }
 
 func SnapLogs(t *testing.T, start time.Time, name string) string {
-	logs, _ := exec(t, snapJournalCommand(start, name), true)
+	logs, _ := exec(t, snapJournalCommand(start, name), false)
 	return logs
 }
 

--- a/test/utils/snap.go
+++ b/test/utils/snap.go
@@ -17,55 +17,55 @@ import (
 // }
 
 func SnapInstallFromStore(t *testing.T, name, channel string) {
-	Exec(t, fmt.Sprintf(
+	exec(t, fmt.Sprintf(
 		"sudo snap install %s --channel=%s",
 		name,
 		channel,
-	))
+	), true)
 }
 
 func SnapInstallFromFile(t *testing.T, path string) {
-	Exec(t, fmt.Sprintf(
+	exec(t, fmt.Sprintf(
 		"sudo snap install --dangerous %s",
 		path,
-	))
+	), true)
 }
 
 func SnapRemove(t *testing.T, names ...string) {
 	for _, name := range names {
-		Exec(t, fmt.Sprintf(
+		exec(t, fmt.Sprintf(
 			"sudo snap remove --purge %s",
 			name,
-		))
+		), true)
 	}
 }
 
 func SnapBuild(t *testing.T, workDir string) {
-	Exec(t, fmt.Sprintf(
+	exec(t, fmt.Sprintf(
 		"cd %s && snapcraft",
 		workDir,
-	))
+	), true)
 }
 
 func SnapConnect(t *testing.T, plug, slot string) {
-	Exec(t, fmt.Sprintf(
+	exec(t, fmt.Sprintf(
 		"sudo snap connect %s %s",
 		plug, slot,
-	))
+	), true)
 }
 
 func SnapDisconnect(t *testing.T, plug, slot string) {
-	Exec(t, fmt.Sprintf(
+	exec(t, fmt.Sprintf(
 		"sudo snap disconnect %s %s",
 		plug, slot,
-	))
+	), true)
 }
 
 func SnapVersion(t *testing.T, name string) string {
-	out, _ := Exec(t, fmt.Sprintf(
+	out, _ := exec(t, fmt.Sprintf(
 		"snap info %s | grep installed | awk '{print $2}'",
 		name,
-	))
+	), true)
 	return strings.TrimSpace(out)
 }
 
@@ -78,59 +78,59 @@ func snapJournalCommand(start time.Time, name string) string {
 
 func SnapDumpLogs(t *testing.T, start time.Time, name string) {
 	const filename = "snap.log" // used in action.yml
-	Exec(t, fmt.Sprintf("(%s) > %s",
+	exec(t, fmt.Sprintf("(%s) > %s",
 		snapJournalCommand(start, name),
-		filename))
+		filename), true)
 
 	wd, _ := os.Getwd()
 	fmt.Printf("Wrote snap logs to %s/%s\n", wd, filename)
 }
 
 func SnapLogs(t *testing.T, start time.Time, name string) string {
-	logs, _ := Exec(t, snapJournalCommand(start, name))
+	logs, _ := exec(t, snapJournalCommand(start, name), true)
 	return logs
 }
 
 func SnapSet(t *testing.T, name, key, value string) {
-	Exec(t, fmt.Sprintf(
+	exec(t, fmt.Sprintf(
 		"sudo snap set %s %s='%s'",
 		name,
 		key,
 		value,
-	))
+	), true)
 }
 
 func SnapUnset(t *testing.T, name, key string) {
-	Exec(t, fmt.Sprintf(
+	exec(t, fmt.Sprintf(
 		"sudo snap unset %s %s",
 		name,
 		key,
-	))
+	), true)
 }
 
 func SnapStart(t *testing.T, names ...string) {
 	for _, name := range names {
-		Exec(t, fmt.Sprintf(
+		exec(t, fmt.Sprintf(
 			"sudo snap start %s",
 			name,
-		))
+		), true)
 	}
 }
 
 func SnapStop(t *testing.T, names ...string) {
 	for _, name := range names {
-		Exec(t, fmt.Sprintf(
+		exec(t, fmt.Sprintf(
 			"sudo snap stop %s",
 			name,
-		))
+		), true)
 	}
 }
 
 func SnapRestart(t *testing.T, names ...string) {
 	for _, name := range names {
-		Exec(t, fmt.Sprintf(
+		exec(t, fmt.Sprintf(
 			"sudo snap restart %s",
 			name,
-		))
+		), true)
 	}
 }


### PR DESCRIPTION

- [x] Fix #71 
- [x] Fix #46
- [x] Set verbose to true where useful, e.g. snap commands

This should pave the way for #78 to allow querying logs periodically without creating too much logs.