### PR TITLE
Remove postgres and redis from public port tests

### DIFF
--- a/test/utils/net.go
+++ b/test/utils/net.go
@@ -65,12 +65,12 @@ func PlatformPorts(includePublicPorts bool) (ports []string) {
 		servicePort("core-command"),
 		servicePort("vault"),
 		servicePort("consul"),
+		servicePort("kong-database"),
+		servicePort("redis"),
 	)
 	if includePublicPorts {
 		ports = append(ports,
 			servicePort("kong"),
-			servicePort("kong-database"),
-			servicePort("redis"),
 		)
 	}
 	return


### PR DESCRIPTION
Depends on:
- https://github.com/edgexfoundry/edgex-go/pull/4154