### PR TITLE
Remove UI service online requirement in setup

### DIFF
--- a/test/suites/ui/main_test.go
+++ b/test/suites/ui/main_test.go
@@ -60,11 +60,5 @@ func setup() (teardown func(), err error) {
 		return
 	}
 
-	// make sure service is online before starting the tests
-	if err = utils.WaitServiceOnline(nil, 60, uiServicePort); err != nil {
-		teardown()
-		return
-	}
-
 	return
 }


### PR DESCRIPTION
This PR updates UI test suite to remove service online requirement in `setup`, in order to support the new adding snap options and default service status - `disable` in PR https://github.com/edgexfoundry/edgex-ui-go/pull/553