### PR TITLE
Test ekuiper subscribe to EdgeX raw events without using ASC by default

### DIFF
--- a/test/suites/edgex-no-sec/ekuiper_test.go
+++ b/test/suites/edgex-no-sec/ekuiper_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/stretchr/testify/require"
-	"io/ioutil"
 	"net/http"
 	"testing"
 )
@@ -58,16 +57,8 @@ func TestRulesEngine(t *testing.T) {
 		}
 		defer resp.Body.Close()
 
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			fmt.Print(err)
-			return
-		}
-
-		err = json.Unmarshal(body, &reading)
-		if err != nil {
-			fmt.Print(err)
-			return
+		if err = json.NewDecoder(resp.Body).Decode(&reading); err != nil {
+			t.Fatal(err)
 		}
 
 		require.Greaterf(t, reading.TotalCount, 0, "No readings have been re-published to EdgeX message bus by ekuiper")

--- a/test/suites/ekuiper/main_test.go
+++ b/test/suites/ekuiper/main_test.go
@@ -17,8 +17,6 @@ const (
 
 	deviceVirtualSnap = "edgex-device-virtual"
 	deviceVirtualPort = "59900"
-
-	ascSnap = "edgex-app-service-configurable"
 )
 
 var testSecretsInterface bool
@@ -30,8 +28,6 @@ func TestMain(m *testing.M) {
 	}
 
 	// set profile to rules engine
-	utils.SnapSet(nil, ascSnap, "profile", "rules-engine")
-
 	testSecretsInterface = true
 
 	code := m.Run()
@@ -64,7 +60,6 @@ func setup() (teardown func(), err error) {
 		ekuiperSnap,
 		"edgexfoundry",
 		deviceVirtualSnap,
-		ascSnap,
 	)
 
 	log.Println("[SETUP]")
@@ -76,13 +71,11 @@ func setup() (teardown func(), err error) {
 		utils.SnapDumpLogs(nil, start, ekuiperSnap)
 		utils.SnapDumpLogs(nil, start, "edgexfoundry")
 		utils.SnapDumpLogs(nil, start, deviceVirtualSnap)
-		utils.SnapDumpLogs(nil, start, ascSnap)
 
 		utils.SnapRemove(nil,
 			ekuiperSnap,
 			"edgexfoundry",
 			deviceVirtualSnap,
-			ascSnap,
 		)
 	}
 
@@ -104,11 +97,6 @@ func setup() (teardown func(), err error) {
 	}
 
 	if err = utils.SnapInstallFromStore(nil, deviceVirtualSnap, utils.ServiceChannel); err != nil {
-		teardown()
-		return
-	}
-
-	if err = utils.SnapInstallFromStore(nil, ascSnap, utils.ServiceChannel); err != nil {
 		teardown()
 		return
 	}

--- a/test/suites/ekuiper/streams_rules_test.go
+++ b/test/suites/ekuiper/streams_rules_test.go
@@ -64,11 +64,11 @@ func TestStreamsAndRules(t *testing.T) {
 
 	// wait device-virtual to come online and produce readings
 	utils.WaitServiceOnline(t, 60, deviceVirtualPort)
+	start := time.Now()
 	utils.TestDeviceVirtualReading(t)
 
 	t.Run("check rule_log", func(t *testing.T) {
 		//check logs for the record of expected log
-		start := time.Now()
 		time.Sleep(1 * time.Second)
 		logs := utils.SnapLogs(t, start, ekuiperSnap)
 		expectLog := "sink result for rule rule_log"

--- a/test/suites/ekuiper/streams_rules_test.go
+++ b/test/suites/ekuiper/streams_rules_test.go
@@ -9,14 +9,12 @@ func TestStreamsAndRules(t *testing.T) {
 	t.Cleanup(func() {
 		utils.SnapStop(t,
 			ekuiperService,
-			deviceVirtualSnap,
-			ascSnap)
+			deviceVirtualSnap)
 	})
 
 	utils.SnapStart(t,
 		ekuiperService,
-		deviceVirtualSnap,
-		ascSnap)
+		deviceVirtualSnap)
 
 	t.Run("create stream", func(t *testing.T) {
 		utils.Exec(t, `edgex-ekuiper.kuiper-cli create stream stream1 '()WITH(FORMAT="JSON",TYPE="edgex")'`)

--- a/test/suites/ekuiper/streams_rules_test.go
+++ b/test/suites/ekuiper/streams_rules_test.go
@@ -4,9 +4,7 @@ import (
 	"edgex-snap-testing/test/utils"
 	"encoding/json"
 	"github.com/stretchr/testify/require"
-	"io/ioutil"
 	"net/http"
-	"strings"
 	"testing"
 	"time"
 )
@@ -16,8 +14,7 @@ type Reading struct {
 }
 
 type RuleStatus struct {
-	SouceCount int `json:"source_stream1_0_records_out_total"`
-	LogCount   int `json:"sink_log_0_0_records_out_total"`
+	LogCount int `json:"sink_log_0_0_records_out_total"`
 }
 
 func TestStreamsAndRules(t *testing.T) {
@@ -67,72 +64,48 @@ func TestStreamsAndRules(t *testing.T) {
 	})
 
 	// wait device-virtual to come online and produce readings
-	utils.WaitServiceOnline(t, 60, deviceVirtualPort)
+	if err := utils.WaitServiceOnline(t, 60, deviceVirtualPort); err != nil {
+		t.Fatal(err)
+	}
 	utils.TestDeviceVirtualReading(t)
 
 	t.Run("check rule_log", func(t *testing.T) {
 		var ruleStatus RuleStatus
-		var body string
 
 		// waiting for readings to come from edgex to ekuiper
 		for i := 1; ; i++ {
 			time.Sleep(1 * time.Second)
-			stdout, _, err := utils.Exec(t, "edgex-ekuiper.kuiper-cli getstatus rule rule_log")
+			resp, err := http.Get("http://localhost:59720/rules/rule_log/status")
 			if err != nil {
 				t.Fatal(err)
 			}
+			defer resp.Body.Close()
 
-			startIndex := strings.Index(stdout, "{")
-
-			if startIndex < 0 {
-				t.Fatal("Error getting status of rule rule_log in JSON format")
-			} else {
-				body = stdout[startIndex:]
-			}
-
-			err = json.Unmarshal([]byte(body), &ruleStatus)
-			if err != nil {
+			if err := json.NewDecoder(resp.Body).Decode(&ruleStatus); err != nil {
 				t.Fatal(err)
 			}
 
 			t.Logf("Waiting for readings to come from edgex to ekuiper, current retry count: %d/60", i)
 
-			if i <= 60 && ruleStatus.SouceCount > 0 {
+			if i <= 60 && ruleStatus.LogCount > 0 {
 				t.Logf("Readings are coming to ekuiper now")
 				break
 			}
 
-			if i > 60 && ruleStatus.SouceCount <= 0 {
+			if i > 60 && ruleStatus.LogCount <= 0 {
 				t.Logf("Waiting for readings to come from edgex to ekuiper, reached maximum retry count of 60")
 				break
 			}
 		}
 
-		stdout, _, err := utils.Exec(t, "edgex-ekuiper.kuiper-cli getstatus rule rule_log")
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		startIndex := strings.Index(stdout, "{")
-
-		if startIndex < 0 {
-			t.Fatal("Error getting status of rule rule_log in JSON format")
-		} else {
-			body = stdout[startIndex:]
-		}
-
-		err = json.Unmarshal([]byte(body), &ruleStatus)
-		if err != nil {
-			t.Fatal(err)
-		}
-
 		require.Greaterf(t, ruleStatus.LogCount, 0, "No readings have been published to log by ekuiper")
-
 	})
 
 	t.Run("check rule_edgex_message_bus", func(t *testing.T) {
 		// wait device-virtual to come online and produce readings
-		utils.WaitServiceOnline(t, 60, deviceVirtualPort)
+		if err := utils.WaitServiceOnline(t, 60, deviceVirtualPort); err != nil {
+			t.Fatal(err)
+		}
 
 		var reading Reading
 		resp, err := http.Get("http://localhost:59880/api/v2/reading/device/name/device-test")
@@ -141,13 +114,7 @@ func TestStreamsAndRules(t *testing.T) {
 		}
 		defer resp.Body.Close()
 
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		err = json.Unmarshal(body, &reading)
-		if err != nil {
+		if err = json.NewDecoder(resp.Body).Decode(&reading); err != nil {
 			t.Fatal(err)
 		}
 

--- a/test/suites/ekuiper/streams_rules_test.go
+++ b/test/suites/ekuiper/streams_rules_test.go
@@ -2,8 +2,19 @@ package test
 
 import (
 	"edgex-snap-testing/test/utils"
+	"encoding/json"
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"io/ioutil"
+	"net/http"
+	"strings"
 	"testing"
+	"time"
 )
+
+type Reading struct {
+	TotalCount int `json:"totalCount"`
+}
 
 func TestStreamsAndRules(t *testing.T) {
 	t.Cleanup(func() {
@@ -56,10 +67,39 @@ func TestStreamsAndRules(t *testing.T) {
 	utils.TestDeviceVirtualReading(t)
 
 	t.Run("check rule_log", func(t *testing.T) {
-		utils.Exec(t, `edgex-ekuiper.kuiper-cli getstatus rule rule_log`)
+		//check logs for the record of expected log
+		start := time.Now()
+		time.Sleep(1 * time.Second)
+		logs := utils.SnapLogs(t, start, ekuiperSnap)
+		expectLog := "sink result for rule rule_log"
+
+		require.True(t, strings.Contains(logs, expectLog))
 	})
 
 	t.Run("check rule_edgex_message_bus", func(t *testing.T) {
-		utils.Exec(t, `edgex-ekuiper.kuiper-cli getstatus rule rule_edgex_message_bus`)
+		// wait device-virtual to come online and produce readings
+		utils.WaitServiceOnline(t, 60, deviceVirtualPort)
+
+		var reading Reading
+		resp, err := http.Get("http://localhost:59880/api/v2/reading/device/name/device-test")
+		if err != nil {
+			fmt.Print(err)
+			return
+		}
+		defer resp.Body.Close()
+
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			fmt.Print(err)
+			return
+		}
+
+		err = json.Unmarshal(body, &reading)
+		if err != nil {
+			fmt.Print(err)
+			return
+		}
+
+		require.Greaterf(t, reading.TotalCount, 0, "No readings have been re-published to EdgeX message bus by ekuiper")
 	})
 }

--- a/test/utils/readings.go
+++ b/test/utils/readings.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/stretchr/testify/require"
-	"io/ioutil"
 	"net/http"
 	"testing"
 	"time"
@@ -30,16 +29,8 @@ func TestDeviceVirtualReading(t *testing.T) {
 			}
 			defer resp.Body.Close()
 
-			body, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				fmt.Print(err)
-				return
-			}
-
-			err = json.Unmarshal(body, &eventCount)
-			if err != nil {
-				fmt.Print(err)
-				return
+			if err = json.NewDecoder(resp.Body).Decode(&eventCount); err != nil {
+				t.Fatal(err)
 			}
 
 			t.Logf("waiting for device-virtual to produce readings, current retry count: %d/60\n", i)

--- a/test/utils/readings.go
+++ b/test/utils/readings.go
@@ -20,7 +20,7 @@ func TestDeviceVirtualReading(t *testing.T) {
 	t.Run("query readings", func(t *testing.T) {
 		var eventCount EventCount
 
-		// wait device-virtual producing readings with maximum 60 seconds
+		// wait device-virtual to produce readings with maximum 60 seconds
 		for i := 1; ; i++ {
 			time.Sleep(1 * time.Second)
 			resp, err := http.Get("http://localhost:59880/api/v2/event/count")
@@ -42,7 +42,7 @@ func TestDeviceVirtualReading(t *testing.T) {
 				return
 			}
 
-			t.Logf("waiting for device-virtual produce readings, current retry count: %d/60\n", i)
+			t.Logf("waiting for device-virtual to produce readings, current retry count: %d/60\n", i)
 
 			if i <= 60 && eventCount.Count > 0 {
 				t.Logf("device-virtual is producing readings now, readings queried from core-data")
@@ -50,7 +50,7 @@ func TestDeviceVirtualReading(t *testing.T) {
 			}
 
 			if i > 60 && eventCount.Count <= 0 {
-				t.Logf("waiting for device-virtual produce readings, reached maximum retry count of 60")
+				t.Logf("waiting for device-virtual to produce readings, reached maximum retry count of 60")
 				break
 			}
 		}


### PR DESCRIPTION
todo:
- [x] Rebase after https://github.com/canonical/edgex-snap-testing/pull/124 has been merged
- [x] Re-run test after https://github.com/canonical/edgex-ekuiper-snap/pull/34 PR has been merged