### PR TITLE
Correct platform/service channel documentation

### DIFF
--- a/test/utils/env.go
+++ b/test/utils/env.go
@@ -8,8 +8,8 @@ import (
 const (
 	// environment variables
 	// used to override defaults
-	platformChannelEnv = "PLATFORM_CHANNEL" // edgexfoundry channel when testing other snaps (has default)
-	serviceChannelEnv  = "SERVICE_CHANNEL"  // channel of the snap to be tested (has default)
+	platformChannelEnv = "PLATFORM_CHANNEL" // channel of the edgexfoundry snap (has default)
+	serviceChannelEnv  = "SERVICE_CHANNEL"  // channel of the service snap (has default)
 	localSnapEnv       = "LOCAL_SNAP"       // path to local snap to be tested instead of downloading from a channel
 	fullConfigTestEnv  = "FULL_CONFIG_TEST" // toggle full config tests (has default)
 )


### PR DESCRIPTION
PR https://github.com/canonical/edgex-snap-testing/pull/110 changed the environment variable used to test edgexfoundry snap from SERVICE_CHANNEL to PLATFORM_CHANNEL.

This makes the comments invalid, as the original design was to use the channel input of Github action or SERVICE_CHANNEL env var to set the channel of the main application being tested, whether it is the platform or another service. Nevertheless, I think this change reduces confusion, so I am updating the comments.