### PR TITLE
Set default input branch to Github Action's default

### DIFF
--- a/build/action.yml
+++ b/build/action.yml
@@ -11,7 +11,7 @@ inputs:
   branch:
     description: Source code repo branch
     required: false
-    default: main
+    default: ${{github.ref}}
 
 outputs:
   snap:


### PR DESCRIPTION
The ability to customize the branch was introduces recently in https://github.com/canonical/edgex-snap-testing/pull/139

This however introduces a bug. Because the default is set to `main`, PRs that don't set the branch take their code from the `main` branch instead of the PR branch.