### PR TITLE
Run TestChangePort only when a subtest is required

### DIFF
--- a/test/utils/config.go
+++ b/test/utils/config.go
@@ -32,24 +32,26 @@ func TestConfig(t *testing.T, snapName string, conf Config) {
 }
 
 func TestChangePort(t *testing.T, snapName string, conf ConfigChangePort) {
-	t.Run("change service port", func(t *testing.T) {
+	if conf.TestAppConfig || conf.TestGlobalConfig || conf.TestMixedGlobalAppConfig {
+		t.Run("change service port", func(t *testing.T) {
 
-		// start once so that default configs get uploaded to the registry
-		service := snapName + "." + conf.App
-		SnapStart(nil, service)
-		WaitServiceOnline(nil, 60, conf.DefaultPort)
-		SnapStop(nil, service)
+			// start once so that default configs get uploaded to the registry
+			service := snapName + "." + conf.App
+			SnapStart(t, service)
+			WaitServiceOnline(t, 60, conf.DefaultPort)
+			SnapStop(t, service)
 
-		if conf.TestAppConfig {
-			testChangePort_app(t, snapName, conf.App, conf.DefaultPort)
-		}
-		if conf.TestGlobalConfig {
-			testChangePort_global(t, snapName, conf.App, conf.DefaultPort)
-		}
-		if conf.TestMixedGlobalAppConfig {
-			testChangePort_mixedGlobalApp(t, snapName, conf.App, conf.DefaultPort)
-		}
-	})
+			if conf.TestAppConfig {
+				testChangePort_app(t, snapName, conf.App, conf.DefaultPort)
+			}
+			if conf.TestGlobalConfig {
+				testChangePort_global(t, snapName, conf.App, conf.DefaultPort)
+			}
+			if conf.TestMixedGlobalAppConfig {
+				testChangePort_mixedGlobalApp(t, snapName, conf.App, conf.DefaultPort)
+			}
+		})
+	}
 }
 
 func testChangePort_app(t *testing.T, snap, app, servicePort string) {


### PR DESCRIPTION
The errors from snap start/stop commands weren't captured and that was hiding another bug.

This was causing the edgex-ekuiper tests to fail silently:
```
2023/01/13 14:37:09 [CLEAN]
2023/01/13 14:37:09 [exec] sudo snap remove --purge edgex-ekuiper
[sudo] password for ubuntu: 
2023/01/13 14:37:11 [stderr] snap "edgex-ekuiper" is not installed
2023/01/13 14:37:11 [exec] sudo snap remove --purge edgexfoundry
2023/01/13 14:37:11 [stderr] snap "edgexfoundry" is not installed
2023/01/13 14:37:11 [exec] sudo snap remove --purge edgex-device-virtual
2023/01/13 14:37:11 [stderr] snap "edgex-device-virtual" is not installed
2023/01/13 14:37:11 [SETUP]
2023/01/13 14:37:11 [exec] sudo snap install --dangerous /home/ubuntu/projects/edgex-ekuiper-snap/edgex-ekuiper_1.7.3+snap+git2.d0fea41_amd64.snap
2023/01/13 14:37:15 [stdout] edgex-ekuiper 1.7.3+snap+git2.d0fea41 installed
2023/01/13 14:37:15 [exec] sudo snap install edgexfoundry --channel=latest/edge
2023/01/13 14:37:54 [stdout] edgexfoundry (edge) 3.0.0-dev.15 from Canonical** installed
2023/01/13 14:37:54 [exec] sudo snap install edgex-device-virtual --channel=latest/edge
2023/01/13 14:37:59 [stdout] edgex-device-virtual (edge) 3.0.0-dev.4 from Canonical** installed
2023/01/13 14:37:59 [exec] sudo snap connect edgexfoundry:edgex-secretstore-token edgex-ekuiper:edgex-secretstore-token
2023/01/13 14:38:01 Retry 1/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command), 8200 (vault), 8500 (consul), 5432 (kong-database), 6379 (redis), 8000 (kong)
=== RUN   TestCommon
=== RUN   TestCommon/content_interfaces
=== RUN   TestCommon/content_interfaces/seed_secretstore_token
    exec.go:19: [exec] sudo cat /var/snap/edgexfoundry/current/secrets/edgex-ekuiper/secrets-token.json
    exec.go:19: [exec] sudo cat /var/snap/edgex-ekuiper/current/edgex-ekuiper/secrets-token.json
=== RUN   TestCommon/config
=== RUN   TestCommon/config/change_service_port
2023/01/13 14:38:01 [exec] sudo snap start --enable edgex-ekuiper.
2023/01/13 14:38:01 [stderr] error: snap "edgex-ekuiper" has no service ""
2023/01/13 14:38:01 Retry 1/60: Waiting for ports: 
2023/01/13 14:38:02 Retry 2/60: Waiting for ports: 
2023/01/13 14:38:03 Retry 3/60: Waiting for ports: 
2023/01/13 14:38:04 Retry 4/60: Waiting for ports: 
2023/01/13 14:38:05 Retry 5/60: Waiting for ports: 
2023/01/13 14:38:06 Retry 6/60: Waiting for ports: 
2023/01/13 14:38:07 Retry 7/60: Waiting for ports: 
2023/01/13 14:38:08 Retry 8/60: Waiting for ports: 
2023/01/13 14:38:09 Retry 9/60: Waiting for ports: 
2023/01/13 14:38:10 Retry 10/60: Waiting for ports: 
2023/01/13 14:38:11 Retry 11/60: Waiting for ports: 
2023/01/13 14:38:12 Retry 12/60: Waiting for ports: 
2023/01/13 14:38:13 Retry 13/60: Waiting for ports: 
2023/01/13 14:38:14 Retry 14/60: Waiting for ports: 
2023/01/13 14:38:15 Retry 15/60: Waiting for ports: 
2023/01/13 14:38:16 Retry 16/60: Waiting for ports: 
2023/01/13 14:38:17 Retry 17/60: Waiting for ports: 
2023/01/13 14:38:18 Retry 18/60: Waiting for ports: 
2023/01/13 14:38:19 Retry 19/60: Waiting for ports: 
2023/01/13 14:38:20 Retry 20/60: Waiting for ports: 
2023/01/13 14:38:21 Retry 21/60: Waiting for ports: 
2023/01/13 14:38:22 Retry 22/60: Waiting for ports: 
2023/01/13 14:38:23 Retry 23/60: Waiting for ports: 
2023/01/13 14:38:24 Retry 24/60: Waiting for ports: 
2023/01/13 14:38:25 Retry 25/60: Waiting for ports: 
2023/01/13 14:38:26 Retry 26/60: Waiting for ports: 
2023/01/13 14:38:27 Retry 27/60: Waiting for ports: 
2023/01/13 14:38:28 Retry 28/60: Waiting for ports: 
2023/01/13 14:38:29 Retry 29/60: Waiting for ports: 
2023/01/13 14:38:30 Retry 30/60: Waiting for ports: 
2023/01/13 14:38:31 Retry 31/60: Waiting for ports: 
2023/01/13 14:38:32 Retry 32/60: Waiting for ports: 
2023/01/13 14:38:33 Retry 33/60: Waiting for ports: 
2023/01/13 14:38:34 Retry 34/60: Waiting for ports: 
2023/01/13 14:38:35 Retry 35/60: Waiting for ports: 
2023/01/13 14:38:36 Retry 36/60: Waiting for ports: 
2023/01/13 14:38:37 Retry 37/60: Waiting for ports: 
2023/01/13 14:38:38 Retry 38/60: Waiting for ports: 
2023/01/13 14:38:39 Retry 39/60: Waiting for ports: 
2023/01/13 14:38:40 Retry 40/60: Waiting for ports: 
2023/01/13 14:38:41 Retry 41/60: Waiting for ports: 
2023/01/13 14:38:42 Retry 42/60: Waiting for ports: 
2023/01/13 14:38:43 Retry 43/60: Waiting for ports: 
2023/01/13 14:38:44 Retry 44/60: Waiting for ports: 
2023/01/13 14:38:45 Retry 45/60: Waiting for ports: 
2023/01/13 14:38:46 Retry 46/60: Waiting for ports: 
2023/01/13 14:38:47 Retry 47/60: Waiting for ports: 
2023/01/13 14:38:48 Retry 48/60: Waiting for ports: 
2023/01/13 14:38:49 Retry 49/60: Waiting for ports: 
2023/01/13 14:38:50 Retry 50/60: Waiting for ports: 
2023/01/13 14:38:51 Retry 51/60: Waiting for ports: 
2023/01/13 14:38:52 Retry 52/60: Waiting for ports: 
2023/01/13 14:38:53 Retry 53/60: Waiting for ports: 
2023/01/13 14:38:54 Retry 54/60: Waiting for ports: 
2023/01/13 14:38:55 Retry 55/60: Waiting for ports: 
2023/01/13 14:38:56 Retry 56/60: Waiting for ports: 
2023/01/13 14:38:57 Retry 57/60: Waiting for ports: 
2023/01/13 14:38:58 Retry 58/60: Waiting for ports: 
2023/01/13 14:38:59 Retry 59/60: Waiting for ports: 
2023/01/13 14:39:00 Retry 60/60: Waiting for ports: 
2023/01/13 14:39:01 [exec] sudo snap stop --disable edgex-ekuiper.
2023/01/13 14:39:01 [stderr] error: snap "edgex-ekuiper" has no service ""
=== RUN   TestCommon/config/autostart
=== RUN   TestCommon/config/autostart/set_and_unset_global_autostart
    exec.go:19: [exec] sudo snap stop --disable edgex-ekuiper
    exec.go:93: [stdout] Stopped.
    exec.go:19: [exec] snap services edgex-ekuiper | awk 'FNR == 2 {print $2}'
    exec.go:93: [stdout] disabled
    exec.go:19: [exec] snap services edgex-ekuiper | awk 'FNR == 2 {print $3}'
    exec.go:93: [stdout] inactive
    exec.go:19: [exec] sudo snap set edgex-ekuiper autostart='true'
    exec.go:19: [exec] snap services edgex-ekuiper | awk 'FNR == 2 {print $2}'
    exec.go:93: [stdout] enabled
    exec.go:19: [exec] snap services edgex-ekuiper | awk 'FNR == 2 {print $3}'
    exec.go:93: [stdout] active
    exec.go:19: [exec] sudo snap unset edgex-ekuiper autostart
    exec.go:19: [exec] snap services edgex-ekuiper | awk 'FNR == 2 {print $2}'
    exec.go:93: [stdout] enabled
    exec.go:19: [exec] snap services edgex-ekuiper | awk 'FNR == 2 {print $3}'
    exec.go:93: [stdout] active
    exec.go:19: [exec] sudo snap set edgex-ekuiper autostart='false'
    exec.go:19: [exec] snap services edgex-ekuiper | awk 'FNR == 2 {print $2}'
    exec.go:93: [stdout] disabled
    exec.go:19: [exec] snap services edgex-ekuiper | awk 'FNR == 2 {print $3}'
    exec.go:93: [stdout] inactive
    exec.go:19: [exec] sudo snap unset edgex-ekuiper autostart
    exec.go:19: [exec] sudo snap stop --disable edgex-ekuiper
    exec.go:93: [stdout] Stopped.
=== RUN   TestCommon/net
    exec.go:19: [exec] sudo snap start --enable edgex-ekuiper
    exec.go:93: [stdout] Started.
=== RUN   TestCommon/net/ports_open
    net.go:140: Retry 1/60: Waiting for ports: 20498 (ekuiper), 59720 (ekuiper/rest-api)
=== CONT  TestCommon/net
    net.go:140: Retry 1/60: Waiting for ports: 20498 (ekuiper), 59720 (ekuiper/rest-api)
=== RUN   TestCommon/net/ports_not_listening_on_all_interfaces
    exec.go:19: [exec] sudo lsof -nPi :20498 || true
    net.go:260: Looking for '*:20498 (LISTEN)'
    exec.go:19: [exec] sudo lsof -nPi :59720 || true
    net.go:260: Looking for '*:59720 (LISTEN)'
=== RUN   TestCommon/net/ports_listening_on_localhost
    exec.go:19: [exec] sudo lsof -nPi :20498 || true
    net.go:260: Looking for '127.0.0.1:20498 (LISTEN)'
    exec.go:19: [exec] sudo lsof -nPi :59720 || true
    net.go:260: Looking for '127.0.0.1:59720 (LISTEN)'
=== CONT  TestCommon/net
    exec.go:19: [exec] sudo snap stop --disable edgex-ekuiper
    exec.go:93: [stdout] 2023-01-13T14:39:05Z INFO Waiting for "snap.edgex-ekuiper.kuiper.service" to stop.
    exec.go:93: [stdout] Stopped.
=== RUN   TestCommon/packaging
=== RUN   TestCommon/packaging/semantic_snap_version
    exec.go:19: [exec] snap info edgex-ekuiper | grep installed | awk '{print $2}'
    exec.go:93: [stdout] 1.7.3+snap+git2.d0fea41
--- PASS: TestCommon (69.32s)
    --- PASS: TestCommon/content_interfaces (0.01s)
        --- PASS: TestCommon/content_interfaces/seed_secretstore_token (0.01s)
    --- PASS: TestCommon/config (62.92s)
        --- PASS: TestCommon/config/change_service_port (60.09s)
        --- PASS: TestCommon/config/autostart (2.83s)
            --- PASS: TestCommon/config/autostart/set_and_unset_global_autostart (2.83s)
    --- PASS: TestCommon/net (6.13s)
        --- PASS: TestCommon/net/ports_open (0.00s)
        --- PASS: TestCommon/net/ports_not_listening_on_all_interfaces (0.06s)
        --- PASS: TestCommon/net/ports_listening_on_localhost (0.03s)
    --- PASS: TestCommon/packaging (0.26s)
        --- PASS: TestCommon/packaging/semantic_snap_version (0.26s)
=== RUN   TestStreamsAndRules
    exec.go:19: [exec] sudo snap start --enable edgex-ekuiper.kuiper
    exec.go:93: [stdout] Started.
    exec.go:19: [exec] sudo snap start --enable edgex-device-virtual
    exec.go:93: [stdout] Started.
=== RUN   TestStreamsAndRules/create_stream
    exec.go:19: [exec] edgex-ekuiper.kuiper-cli create stream stream1 '()WITH(FORMAT="JSON",TYPE="edgex")'
=== RUN   TestStreamsAndRules/create_rule_log
    exec.go:19: [exec] edgex-ekuiper.kuiper-cli create rule rule_log '
                                {
                                        "sql":"SELECT * FROM stream1 WHERE meta(deviceName) != \"device-test\"",
                                        "actions":[
                                                {
                                                        "log":{}
                                                }
                                        ]
                                }'
=== RUN   TestStreamsAndRules/create_rule_edgex_message_bus
    exec.go:19: [exec] edgex-ekuiper.kuiper-cli create rule rule_edgex_message_bus '
                                {
                                   "sql":"SELECT * FROM stream1 WHERE meta(deviceName) != \"device-test\"",
                                   "actions": [
                                          {
                                                 "edgex": {
                                                        "connectionSelector": "edgex.redisMsgBus",
                                                        "topicPrefix": "edgex/events/device", 
                                                        "messageType": "request",
                                                        "deviceName": "device-test"
                                                 }
                                          }
                                   ]
                                }'
=== CONT  TestStreamsAndRules
    net.go:140: Retry 1/60: Waiting for ports: 59900 (device-virtual)
    net.go:140: Retry 2/60: Waiting for ports: 59900 (device-virtual)
=== RUN   TestStreamsAndRules/query_readings
    readings.go:36: waiting for device-virtual to produce readings, current retry count: 1/60
    readings.go:36: waiting for device-virtual to produce readings, current retry count: 2/60
    readings.go:36: waiting for device-virtual to produce readings, current retry count: 3/60
    readings.go:36: waiting for device-virtual to produce readings, current retry count: 4/60
    readings.go:36: waiting for device-virtual to produce readings, current retry count: 5/60
    readings.go:36: waiting for device-virtual to produce readings, current retry count: 6/60
    readings.go:36: waiting for device-virtual to produce readings, current retry count: 7/60
    readings.go:36: waiting for device-virtual to produce readings, current retry count: 8/60
    readings.go:36: waiting for device-virtual to produce readings, current retry count: 9/60
    readings.go:36: waiting for device-virtual to produce readings, current retry count: 10/60
    readings.go:39: device-virtual is producing readings now, readings queried from core-data
=== RUN   TestStreamsAndRules/check_rule_log
    streams_rules_test.go:88: Waiting for readings to come from edgex to ekuiper, current retry count: 1/60
    streams_rules_test.go:91: Readings are coming to ekuiper now
=== RUN   TestStreamsAndRules/check_rule_edgex_message_bus
    net.go:140: Retry 1/60: Waiting for ports: 59900 (device-virtual)
=== CONT  TestStreamsAndRules
    exec.go:19: [exec] sudo snap stop --disable edgex-ekuiper.kuiper
    exec.go:93: [stdout] Stopped.
    exec.go:19: [exec] sudo snap stop --disable edgex-device-virtual
    exec.go:93: [stdout] 2023-01-13T14:39:25Z INFO Waiting for "snap.edgex-device-virtual.device-virtual.service" to stop.
    exec.go:93: [stdout] Stopped.
--- PASS: TestStreamsAndRules (18.54s)
    --- PASS: TestStreamsAndRules/create_stream (0.19s)
    --- PASS: TestStreamsAndRules/create_rule_log (0.03s)
    --- PASS: TestStreamsAndRules/create_rule_edgex_message_bus (0.03s)
    --- PASS: TestStreamsAndRules/query_readings (10.01s)
    --- PASS: TestStreamsAndRules/check_rule_log (1.00s)
    --- PASS: TestStreamsAndRules/check_rule_edgex_message_bus (0.00s)
PASS
2023/01/13 14:39:29 [TEARDOWN]
2023/01/13 14:39:29 [exec] (sudo journalctl --since "2023-01-13 14:37:11" --no-pager | grep "edgex-ekuiper"|| true) > edgex-ekuiper.log
Wrote snap logs to /home/ubuntu/projects/edgex-snap-testing/test/suites/ekuiper/edgex-ekuiper.log
2023/01/13 14:39:29 [exec] (sudo journalctl --since "2023-01-13 14:37:11" --no-pager | grep "edgexfoundry"|| true) > edgexfoundry.log
Wrote snap logs to /home/ubuntu/projects/edgex-snap-testing/test/suites/ekuiper/edgexfoundry.log
2023/01/13 14:39:29 [exec] (sudo journalctl --since "2023-01-13 14:37:11" --no-pager | grep "edgex-device-virtual"|| true) > edgex-device-virtual.log
Wrote snap logs to /home/ubuntu/projects/edgex-snap-testing/test/suites/ekuiper/edgex-device-virtual.log
2023/01/13 14:39:29 [exec] sudo snap remove --purge edgex-ekuiper
2023/01/13 14:39:32 [stdout] edgex-ekuiper removed
2023/01/13 14:39:32 [exec] sudo snap remove --purge edgexfoundry
2023/01/13 14:39:33 [stdout] 2023-01-13T14:39:33Z INFO Waiting for "snap.edgexfoundry.core-data.service" to stop.
2023/01/13 14:39:35 [stdout] 2023-01-13T14:39:34Z INFO Waiting for "snap.edgexfoundry.core-metadata.service" to stop.
2023/01/13 14:39:42 [stdout] edgexfoundry removed
2023/01/13 14:39:42 [exec] sudo snap remove --purge edgex-device-virtual
2023/01/13 14:39:43 [stdout] edgex-device-virtual removed
ok      edgex-snap-testing/test/suites/ekuiper  154.678s
```