### PR TITLE
Split refresh tests to a separate package

### DIFF
--- a/test/suites/edgexfoundry/main_test.go
+++ b/test/suites/edgexfoundry/main_test.go
@@ -49,8 +49,6 @@ func TestCommon(t *testing.T) {
 	utils.TestPackaging(t, platformSnap, utils.Packaging{
 		TestSemanticSnapVersion: true,
 	})
-
-	utils.TestRefresh(t, platformSnap)
 }
 
 func setup() (teardown func(), err error) {

--- a/test/suites/edgexfoundry/refresh/refresh_test.go
+++ b/test/suites/edgexfoundry/refresh/refresh_test.go
@@ -1,0 +1,14 @@
+package test
+
+import (
+	"edgex-snap-testing/test/utils"
+	"testing"
+)
+
+const (
+	platformSnap = "edgexfoundry"
+)
+
+func TestCommon(t *testing.T) {
+	utils.TestRefresh(t, platformSnap)
+}


### PR DESCRIPTION
Fixes #117 

With this change, the following command will not run the refresh tests:
```
go test -v --count=1 ./test/suites/edgexfoundry
```

But the following will:
```
go test -v --count=1 ./test/suites/edgexfoundry/refresh
go test -v --count=1 ./test/suites/edgexfoundry/...
```

As a result, the refresh tests will no longer run with the current configuration of the snap testing workflow. This is expected because we don't need to have passing tests right now as we are going through a major change upstream.