### PR TITLE
Use eKuiper snap name to manage service

### DIFF
--- a/test/suites/edgex-no-sec/ekuiper_test.go
+++ b/test/suites/edgex-no-sec/ekuiper_test.go
@@ -16,13 +16,13 @@ type Reading struct {
 func TestRulesEngine(t *testing.T) {
 	t.Cleanup(func() {
 		utils.SnapStop(t,
-			ekuiperService,
+			ekuiperSnap,
 			deviceVirtualSnap,
 			ascSnap)
 	})
 
 	utils.SnapStart(t,
-		ekuiperService,
+		ekuiperSnap,
 		deviceVirtualSnap,
 		ascSnap)
 

--- a/test/suites/edgex-no-sec/ekuiper_test.go
+++ b/test/suites/edgex-no-sec/ekuiper_test.go
@@ -4,9 +4,10 @@ import (
 	"edgex-snap-testing/test/utils"
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 type Reading struct {
@@ -27,10 +28,10 @@ func TestRulesEngine(t *testing.T) {
 		ascSnap)
 
 	t.Run("create stream and rule", func(t *testing.T) {
-		utils.Exec(t, `edgex-ekuiper.kuiper-cli create stream stream1 '()WITH(FORMAT="JSON",TYPE="edgex")'`)
+		utils.Exec(t, `edgex-ekuiper.kuiper create stream stream1 '()WITH(FORMAT="JSON",TYPE="edgex")'`)
 
 		utils.Exec(t,
-			`edgex-ekuiper.kuiper-cli create rule rule_edgex_message_bus '
+			`edgex-ekuiper.kuiper create rule rule_edgex_message_bus '
 			{
 			   "sql":"SELECT * from stream1",
 			   "actions": [

--- a/test/suites/ekuiper/main_test.go
+++ b/test/suites/ekuiper/main_test.go
@@ -10,8 +10,6 @@ import (
 
 const (
 	ekuiperSnap           = "edgex-ekuiper"
-	ekuiperApp            = "kuiperd"
-	ekuiperService        = ekuiperSnap + "." + ekuiperApp
 	ekuiperServerPort     = "20498"
 	ekuiperRestfulApiPort = "59720"
 

--- a/test/suites/ekuiper/streams_rules_test.go
+++ b/test/suites/ekuiper/streams_rules_test.go
@@ -3,10 +3,11 @@ package test
 import (
 	"edgex-snap-testing/test/utils"
 	"encoding/json"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 type Reading struct {
@@ -20,12 +21,12 @@ type RuleStatus struct {
 func TestStreamsAndRules(t *testing.T) {
 	t.Cleanup(func() {
 		utils.SnapStop(t,
-			ekuiperService,
+			ekuiperSnap,
 			deviceVirtualSnap)
 	})
 
 	utils.SnapStart(t,
-		ekuiperService,
+		ekuiperSnap,
 		deviceVirtualSnap)
 
 	t.Run("create stream", func(t *testing.T) {


### PR DESCRIPTION
- Use snap to be consistent with other stop/start operations in this suite and to reduce verbosity. 
- Fix remaining names, missed in https://github.com/canonical/edgex-snap-testing/pull/151
- Refactor startup and wait code to speedup the tests