### PR TITLE
Extend the retention period for artifacts

### DIFF
--- a/test/action.yml
+++ b/test/action.yml
@@ -89,4 +89,4 @@ runs:
       with:
         name: ${{inputs.name}}-logs
         path: ${{env.action_path}}/suites/${{inputs.name}}/*.log
-        retention-days: 7
+        retention-days: 30


### PR DESCRIPTION
The builds use 30d as well since https://github.com/canonical/edgex-snap-testing/pull/142