### PR TITLE
Allow testing by revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The environment variables are defined in [test/utils/env.go](./test/utils/env.go
 
 Full config test:
 ```bash
-FULL_CONFIG_TEST=true go -v test ./test/suites/device-mqtt
+FULL_CONFIG_TEST=true go test -v ./test/suites/device-mqtt
 ```
 
 Testing with a local snap:

--- a/README.md
+++ b/README.md
@@ -55,8 +55,13 @@ Testing with a local snap:
 ```bash
 LOCAL_SNAP="edgex-device-mqtt_2.0.1-dev.15_amd64.snap" go test -v --count=1 ./test/suites/device-mqtt
 ```
-
 The `--count=1` flag is to avoid Go test caching when testing the rebuilt snap.
+
+Test by revision:
+```
+PLATFORM_CHANNEL=4259 go test -v ./test/suites/edgex-no-sec
+```
+This requires developer access; see `snap install -h` for details.
 
 #### Run only one test from a suite
 ```

--- a/test/utils/env.go
+++ b/test/utils/env.go
@@ -8,8 +8,8 @@ import (
 const (
 	// environment variables
 	// used to override defaults
-	platformChannelEnv = "PLATFORM_CHANNEL" // channel of the edgexfoundry snap (has default)
-	serviceChannelEnv  = "SERVICE_CHANNEL"  // channel of the service snap (has default)
+	platformChannelEnv = "PLATFORM_CHANNEL" // channel/revision of the edgexfoundry snap (has default)
+	serviceChannelEnv  = "SERVICE_CHANNEL"  // channel/revision of the service snap (has default)
 	localSnapEnv       = "LOCAL_SNAP"       // path to local snap to be tested instead of downloading from a channel
 	fullConfigTestEnv  = "FULL_CONFIG_TEST" // toggle full config tests (has default)
 )

--- a/test/utils/snap.go
+++ b/test/utils/snap.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -17,11 +18,20 @@ import (
 // }
 
 func SnapInstallFromStore(t *testing.T, name, channel string) error {
+
+	option := "--channel"
+	// install by revision if channel is a number
+	if _, err := strconv.Atoi(channel); err == nil {
+		option = "--revision"
+	}
+
 	_, stderr, err := exec(t, fmt.Sprintf(
-		"sudo snap install %s --channel=%s",
+		"sudo snap install %s %s=%s",
 		name,
+		option,
 		channel,
 	), true)
+
 	if err != nil {
 		return fmt.Errorf("%s: %s", err, stderr)
 	}


### PR DESCRIPTION
Example:
```
$ PLATFORM_CHANNEL=4257 go test -v ./test/suites/edgex-no-sec
2023/02/16 12:10:21 [CLEAN]
...
2023/02/16 12:10:21 [SETUP]
2023/02/16 12:10:21 [exec] sudo snap install edgexfoundry --revision=4257
2023/02/16 12:11:10 [stdout] edgexfoundry 3.0.0-dev.36 from Canonical** installed
2023/02/16 12:11:10 [exec] sudo snap install edgex-device-virtual --channel=latest/edge
...
```