### PR TITLE
Capture Device USB Camera's RTSP server errors in build logs

### DIFF
--- a/test/action.yml
+++ b/test/action.yml
@@ -69,7 +69,7 @@ runs:
         echo "::group::Service Errors"
         file=./suites/${{inputs.name}}/${{inputs.name}}.log
         if test -f "$file"; then
-          cat $file | grep --ignore-case "error"
+          cat $file | grep --ignore-case "error\|\bERR\b"
         fi
 
         echo -e "\nFull logs will be uploaded as build artifacts."

--- a/test/action.yml
+++ b/test/action.yml
@@ -69,7 +69,7 @@ runs:
         echo "::group::Service Errors"
         file=./suites/${{inputs.name}}/${{inputs.name}}.log
         if test -f "$file"; then
-          cat $file | grep --ignore-case "error\|\bERR\b"
+          cat $file | grep --ignore-case --extended-regexp --word-regexp "error|ERR"
         fi
 
         echo -e "\nFull logs will be uploaded as build artifacts."


### PR DESCRIPTION
### Test instruction:
1. Create a `test.log`:
```
1. ERR hi
2. override
3. error
4. ERROR ho
5. OVERRIDE
6. err
7. errorrrr
```
2. Validate that if only "error" "ERROR" "err" "ERR" have been captured:
```
cat test.log | grep --ignore-case "error\|\bERR\b"
1. ERR hi
3. error
4. ERROR ho
6. err
```
