### PR TITLE
feat!: Remove secrets-config proxy tests

### DIFF
--- a/test/suites/edgexfoundry/proxy_test.go
+++ b/test/suites/edgexfoundry/proxy_test.go
@@ -17,6 +17,7 @@ import (
 // Test seeding a custom TLS certificate using snap options
 // https://docs.edgexfoundry.org/2.2/getting-started/Ch-GettingStartedSnapUsers/#changing-tls-certificates
 func TestTLSCert(t *testing.T) {
+	t.Skip("Disabled in order to implement breaking changes to secrets-config for microservice token authentication ADR")
 	t.Cleanup(func() {
 		utils.SnapUnset(t, platformSnap, "apps")
 	})
@@ -63,6 +64,7 @@ func TestTLSCert(t *testing.T) {
 // Test seeding an admin user using snap options
 // https://docs.edgexfoundry.org/2.2/getting-started/Ch-GettingStartedSnapUsers/#adding-api-gateway-users
 func TestAddProxyUser(t *testing.T) {
+	t.Skip("Disabled in order to implement breaking changes to secrets-config for microservice token authentication ADR")
 	t.Cleanup(func() {
 		utils.SnapUnset(t, platformSnap, "apps")
 	})


### PR DESCRIPTION
BREAKING CHANGE: As part of microservice token authentication ADR, the behavior of proxy adduser and proxy tls commands is changing. These unit tests are outside of the edgex-go repo blocking the related breaking change.  New tests can be added after the ADR implementation is completed.

cc @MonicaisHer 