### PR TITLE
Fetch errors on test failure from all available log files

### DIFF
--- a/test/action.yml
+++ b/test/action.yml
@@ -61,20 +61,12 @@ runs:
       run: |
         go test -failfast -p 1 -timeout 30m -v ./suites/${{inputs.name}} ${{inputs.go-args}}
 
-    # Print error logs for the service
-    - if: always()
+    # Print error logs from snap(s)
+    - if: failure()
       shell: bash
       working-directory: ${{github.action_path}}
-      run: |
-        echo "::group::Service Errors"
-        file=./suites/${{inputs.name}}/${{inputs.name}}.log
-        if test -f "$file"; then
-          cat $file | grep --ignore-case --extended-regexp --word-regexp "error|ERR"
-        fi
+      run: ./print-errors.sh ${{inputs.name}}
 
-        echo -e "\nFull logs will be uploaded as build artifacts."
-        echo "::endgroup::"
-        
     # For some reason, github.action_path resolves to a wrong path when directly passed to
     # upload-artifact's path or in bash
     - if: always()

--- a/test/print-errors.sh
+++ b/test/print-errors.sh
@@ -4,6 +4,8 @@ suite=$1
 
 pattern="$(dirname "$0")/suites/$suite/*.log"
 for file in $pattern; do
-    echo -e "\nFiltered errors from $file"
+    echo -e "\n🟥 Filtered errors from $file:"
     cat $file | grep --ignore-case --extended-regexp --word-regexp "error|ERR"
 done
+
+echo -e "\n🔎 For full logs, refer to workflow artifacts."

--- a/test/print-errors.sh
+++ b/test/print-errors.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+suite=$1
+
+pattern="$(dirname "$0")/suites/$suite/*.log"
+for file in $pattern; do
+    echo -e "\nFiltered errors from $file"
+    cat $file | grep --ignore-case --extended-regexp --word-regexp "error|ERR"
+done


### PR DESCRIPTION
The log files have the snap name but the action looks for logs with the suite name:

![image](https://user-images.githubusercontent.com/11150423/224002135-aee1f502-7f3f-4628-8b45-2cb13210e618.png)

https://github.com/canonical/edgex-snap-testing/blob/239169bca8d67a2b30593189a8e97264a3292cca/test/action.yml#L64-L76

https://github.com/canonical/edgex-snap-testing/blob/239169bca8d67a2b30593189a8e97264a3292cca/test/utils/snap.go#L127-L131

The snap name isn't available in the action. Moreover, we never fetch the platform errors. This PR changes the action to look for all log files with a pattern and the matching print errors.