### PR TITLE
Run tests without a config provider when testing config options

### DIFF
--- a/test/suites/edgexfoundry/config_test.go
+++ b/test/suites/edgexfoundry/config_test.go
@@ -23,6 +23,8 @@ func TestChangeStartupMsg_app(t *testing.T) {
 		utils.SnapRestart(t, supportSchedulerService)
 	})
 
+	utils.DisableConfigProvider(t, platformSnap, supportSchedulerApp)
+
 	t.Log("Set and verify new startup message:", newStartupMsg)
 	utils.SnapSet(t, platformSnap, startupMsgKey, newStartupMsg)
 	ts := time.Now()
@@ -49,6 +51,8 @@ func TestChangeStartupMsg_global(t *testing.T) {
 		utils.SnapUnset(t, platformSnap, startupMsgKey)
 		utils.SnapRestart(t, supportSchedulerService)
 	})
+
+	utils.DisableConfigProvider(t, platformSnap, supportSchedulerApp)
 
 	t.Log("Set and verify new startup message:", newStartupMsg)
 	utils.SnapSet(t, platformSnap, startupMsgKey, newStartupMsg)
@@ -80,6 +84,8 @@ func TestChangeStartupMsg_mixedGlobalApp(t *testing.T) {
 		utils.SnapRestart(t, supportSchedulerService)
 	})
 
+	utils.DisableConfigProvider(t, platformSnap, supportSchedulerApp)
+
 	t.Log("Set local and global startup messages and verify that local has taken precedence")
 	utils.SnapSet(t, platformSnap, appStartupMsgKey, appNewStartupMsg)
 	utils.SnapSet(t, platformSnap, globalStartupMsgKey, globalNewStartupMsg)
@@ -100,7 +106,6 @@ func TestChangeStartupMsg_mixedGlobalApp(t *testing.T) {
 }
 
 func checkStartupMsg(t *testing.T, snap, expectedMsg string, since time.Time) bool {
-	t.Skip("Skip while working on a fix: https://github.com/canonical/edgex-snap-testing/issues/172")
 	const maxRetry = 10
 
 	utils.WaitPlatformOnline(t)

--- a/test/utils/config.go
+++ b/test/utils/config.go
@@ -33,7 +33,6 @@ func TestConfig(t *testing.T, snapName string, conf Config) {
 
 func TestChangePort(t *testing.T, snapName string, conf ConfigChangePort) {
 	if conf.TestAppConfig || conf.TestGlobalConfig || conf.TestMixedGlobalAppConfig {
-                t.Skip("Skip while working on a fix: https://github.com/canonical/edgex-snap-testing/issues/172")
 		t.Run("change service port", func(t *testing.T) {
 
 			// start once so that default configs get uploaded to the registry
@@ -72,6 +71,8 @@ func testChangePort_app(t *testing.T, snap, app, servicePort string) {
 		// make sure the port is available before using it
 		RequirePortAvailable(t, newPort)
 
+		DisableConfigProvider(t, snap, app)
+
 		// set apps. and validate the new port comes online
 		SnapSet(t, snap, "apps."+app+".config.service-port", newPort)
 		SnapStart(t, service)
@@ -102,6 +103,8 @@ func testChangePort_global(t *testing.T, snap, app, servicePort string) {
 
 		// make sure the port is available before using it
 		RequirePortAvailable(t, newPort)
+
+		DisableConfigProvider(t, snap, app)
 
 		// set config. and validate the new port comes online
 		SnapSet(t, snap, "config.service-port", newPort)
@@ -139,6 +142,8 @@ func testChangePort_mixedGlobalApp(t *testing.T, snap, app, servicePort string) 
 		// make sure the ports are available before using it
 		RequirePortAvailable(t, newAppPort)
 		RequirePortAvailable(t, newConfigPort)
+
+		DisableConfigProvider(t, snap, app)
 
 		// set apps. and config. with different values,
 		// and validate that app-specific option has been picked up because it has higher precedence
@@ -197,4 +202,11 @@ func WaitStartupMsg(t *testing.T, snap, expectedMsg string, since time.Time, ret
 		}
 	}
 	t.Fatalf(`Time out: reached max %d retries looking for "%s"`, retries, expectedMsg)
+}
+
+// DisableConfigProvider disables the config provider for the specified app
+// and sets the common configuration path
+func DisableConfigProvider(t *testing.T, snap, app string) {
+	SnapSet(t, snap, "apps."+app+".config.edgex-config-provider", "none")
+	SnapSet(t, snap, "apps."+app+".config.edgex-common-config", "./config/core-common-config-bootstrapper/res/configuration.yaml")
 }


### PR DESCRIPTION
resolves #172

- [ ] Rerun snap testing once related changes have been made to upstream services