### PR TITLE
Inject devices and profiles dir path to local device configuration

### DIFF
--- a/test/utils/setup.go
+++ b/test/utils/setup.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"log"
+	"strings"
 	"time"
 )
 
@@ -31,7 +32,7 @@ func SetupServiceTests(snapName string) (teardown func(), err error) {
 		}
 	}
 
-	// install the device snap before edgexfoundry
+	// install the device/app service snap before edgexfoundry
 	// to catch build error sooner and stop
 	if LocalSnap() {
 		err = SnapInstallFromFile(nil, LocalSnapPath)
@@ -61,6 +62,14 @@ func SetupServiceTests(snapName string) (teardown func(), err error) {
 	if err = WaitPlatformOnline(nil); err != nil {
 		teardown()
 		return
+	}
+
+	// TODO: remove this patch which is for device services
+	if strings.Contains(snapName, "device-") {
+		err = injectDevicesAndProfilesDirConfig(strings.TrimPrefix(snapName, "edgex-"))
+		if err != nil {
+			log.Fatalf("Failed to inject devices/profiles dir into config: %s", err)
+		}
 	}
 
 	return


### PR DESCRIPTION
This is a temporary fix to fix device services and pass the tests.