### PR TITLE
Fix for ekuiper edgex message bus sink, update security services check

### DIFF
--- a/test/suites/edgex-no-sec/status_test.go
+++ b/test/suites/edgex-no-sec/status_test.go
@@ -9,7 +9,15 @@ import (
 
 func TestServiceStatus(t *testing.T) {
 	t.Run("security services", func(t *testing.T) {
-		var securityServices = []string{"kong-daemon", "postgres", "vault"}
+		var securityServices = []string{
+			"nginx", "vault",
+			"secrets-config-processor",
+			"security-bootstrapper-nginx",
+			"security-bootstrapper-redis",
+			"security-consul-bootstrapper",
+			"security-proxy-auth",
+			"security-secretstore-setup",
+		}
 
 		for _, service := range securityServices {
 			require.False(t, utils.SnapServicesEnabled(t, "edgexfoundry."+service))

--- a/test/suites/ekuiper/streams_rules_test.go
+++ b/test/suites/ekuiper/streams_rules_test.go
@@ -68,7 +68,7 @@ func TestStreamsAndRules(t *testing.T) {
 	if err := utils.WaitServiceOnline(t, 60, utils.ServicePort(deviceVirtualApp)); err != nil {
 		t.Fatal(err)
 	}
-	utils.WaitForReadings(t, true)
+	utils.WaitForReadings(t, "Random-Integer-Device", true)
 
 	t.Run("check rule_log", func(t *testing.T) {
 		var ruleStatus RuleStatus

--- a/test/utils/readings.go
+++ b/test/utils/readings.go
@@ -21,8 +21,8 @@ func LoginTestUser(t *testing.T) (idToken string) {
 
 // WaitForReadings waits for readings to appear in core-data
 // The readings are produced by device-virtual or another service
-func WaitForReadings(t *testing.T, secured bool) {
-	const coreDataReadingCountEndpoint = "http://localhost:59880/api/v2/reading/count"
+func WaitForReadings(t *testing.T, deviceName string, secured bool) {
+	var coreDataReadingCountEndpoint = "http://localhost:59880/api/v2/reading/count/device/name/" + deviceName
 
 	t.Run("query readings count", func(t *testing.T) {
 		var eventCount struct {


### PR DESCRIPTION
This PR adds a check to ensure that readings from ekuiper are coming into EdgeX message bus, while also removing app-service-configurable snap from the edgex-no-sec test. It seems that ASC may be blocking readings from reaching the message bus, but I couldn't identify any specific errors or warnings in ASC.