### PR TITLE
Perform UC test operations on a copy of model assertion

### DIFF
--- a/test/suites/ubuntu-core-edgex-image/.gitignore
+++ b/test/suites/ubuntu-core-edgex-image/.gitignore
@@ -1,5 +1,4 @@
-model.yaml
-model.signed.yaml
+model-test.*
 pc.img
 pc-gadget
 seed.manifest

--- a/test/suites/ubuntu-core-edgex-image/build-image.sh
+++ b/test/suites/ubuntu-core-edgex-image/build-image.sh
@@ -5,21 +5,25 @@ if [[ -z "$KEY_NAME" ]]; then
   exit 1
 fi
 
+MODEL=model-test.yaml
+SIGNED_MODEL=model-test.signed.yaml
+cp model.yaml $MODEL
+
 # Configure model assertion
 DEVELOPER_ID=$(snapcraft whoami | grep 'id:' | awk '{print $2}')
 TIMESTAMP=$(date -Iseconds --utc)
-yq e -i ".authority-id = \"$DEVELOPER_ID\"" model.yaml
-yq e -i ".brand-id = \"$DEVELOPER_ID\"" model.yaml
-yq e -i ".timestamp = \"$TIMESTAMP\"" model.yaml
+yq e -i ".authority-id = \"$DEVELOPER_ID\"" $MODEL
+yq e -i ".brand-id = \"$DEVELOPER_ID\"" $MODEL
+yq e -i ".timestamp = \"$TIMESTAMP\"" $MODEL
 
 # Sign the model assertion
-yq eval model.yaml -o=json | snap sign -k $KEY_NAME > model.signed.yaml
+yq eval $MODEL -o=json | snap sign -k $KEY_NAME > $SIGNED_MODEL
 
 # Check the signed model
-cat model.signed.yaml
+cat $SIGNED_MODEL
 
 # clean and build the image
-ubuntu-image snap model.signed.yaml --validation=enforce --snap pc-gadget/pc_*_amd64.snap
+ubuntu-image snap $SIGNED_MODEL --validation=enforce --snap pc-gadget/pc_*_amd64.snap
 
 # check the image file
 file pc.img

--- a/test/suites/ubuntu-core-edgex-image/clean.sh
+++ b/test/suites/ubuntu-core-edgex-image/clean.sh
@@ -2,7 +2,7 @@
 
 rm -fr \
     pc-gadget \
-    model.signed.yaml \
+    model-test.* \
     pc.img \
     seed.manifest
 

--- a/test/suites/ubuntu-core-edgex-image/model.yaml
+++ b/test/suites/ubuntu-core-edgex-image/model.yaml
@@ -1,8 +1,8 @@
 type: model
 series: '16'
 # authority-id and brand-id must be set to your developer-id
-authority-id: 3ehWphH4KXEI2BY8mla8ydYPJm8BCfkd
-brand-id: 3ehWphH4KXEI2BY8mla8ydYPJm8BCfkd
+authority-id: <developer-id>
+brand-id: <developer-id>
 model: ubuntu-core-22-amd64
 architecture: amd64
 # timestamp should be within your signature's validity period


### PR DESCRIPTION
The script was making changes to the reference model assertion file and then ignoring those changes via `.gitignore`. This made it hard to make intended changes that need to be version controlled.

This PR makes it such that the changes are done on a copy, which is not version controlled.