### PR TITLE
Revert device profile injection

### DIFF
--- a/test/suites/device-usb-camera/main_test.go
+++ b/test/suites/device-usb-camera/main_test.go
@@ -40,7 +40,7 @@ func TestCommon(t *testing.T) {
 	utils.TestConfig(t, deviceUSBCamSnap, utils.Config{
 		TestChangePort: utils.ConfigChangePort{
 			App:                      deviceUSBCamApp,
-			DefaultPort:              deviceUSBCamPort,
+			DefaultPort:              deviceUSBCamServicePort,
 			TestAppConfig:            true,
 			TestGlobalConfig:         true,
 			TestMixedGlobalAppConfig: utils.FullConfigTest,

--- a/test/suites/edgex-no-sec/ekuiper_test.go
+++ b/test/suites/edgex-no-sec/ekuiper_test.go
@@ -46,12 +46,6 @@ func TestRulesEngine(t *testing.T) {
 	utils.SnapInstallFromStore(t, deviceVirtualSnap, utils.ServiceChannel)
 	utils.SnapInstallFromStore(t, ekuiperSnap, utils.ServiceChannel)
 
-	// TODO: temporary fix
-	err := utils.InjectDevicesAndProfilesDirConfig("device-virtual")
-	if err != nil {
-		log.Fatalf("Failed to inject devices/profiles dir into config: %s", err)
-	}
-
 	// turn security off
 	utils.SnapSet(t, deviceVirtualSnap, "config.edgex-security-secret-store", "false")
 	utils.SnapSet(t, ekuiperSnap, "config.edgex-security-secret-store", "false")

--- a/test/suites/ekuiper/main_test.go
+++ b/test/suites/ekuiper/main_test.go
@@ -126,11 +126,5 @@ func setup() (teardown func(), err error) {
 		return
 	}
 
-	// TODO: temporary fix
-	err = utils.InjectDevicesAndProfilesDirConfig("device-virtual")
-	if err != nil {
-		log.Fatalf("Failed to inject devices/profiles dir into config: %s", err)
-	}
-
 	return
 }

--- a/test/utils/config.go
+++ b/test/utils/config.go
@@ -1,11 +1,8 @@
 package utils
 
 import (
-	"bytes"
-	"fmt"
 	"strings"
 	"testing"
-	"text/template"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -211,30 +208,6 @@ func DoNotUseConfigProviderServiceSnap(t *testing.T, snap, app string) {
 	Exec(t, "sudo cp "+sourceFile+" "+destFile)
 
 	SnapSet(t, snap, "apps."+app+".config.edgex-common-config", destFile)
-}
-
-// TODO: remove once the following issue is resolved: https://github.com/edgexfoundry/device-sdk-go/issues/1414
-func InjectDevicesAndProfilesDirConfig(app string) error {
-	const confPathTempl = "/var/snap/edgex-{{.}}/current/config/{{.}}/res/configuration.yaml"
-	const confTempl = `
-# Local config to override the common setting
-Device:
-  ProfilesDir: /var/snap/edgex-{{.}}/current/config/{{.}}/res/profiles
-  DevicesDir: /var/snap/edgex-{{.}}/current/config/{{.}}/res/devices
-`
-	var tpl bytes.Buffer
-	template.Must(template.New("temp").Parse(confTempl)).Execute(&tpl, app)
-	conf := tpl.String()
-
-	tpl.Reset()
-	template.Must(template.New("temp").Parse(confPathTempl)).Execute(&tpl, app)
-	confPath := tpl.String()
-
-	stdout, stderr, err := Exec(nil, "echo '"+conf+"' | sudo tee -a "+confPath)
-	if err != nil {
-		return fmt.Errorf("%s %s %s", stdout, stderr, err)
-	}
-	return nil
 }
 
 func WaitForLogMessage(t *testing.T, snap, expectedLog string, since time.Time) bool {

--- a/test/utils/setup.go
+++ b/test/utils/setup.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"log"
-	"strings"
 	"time"
 )
 
@@ -62,14 +61,6 @@ func SetupServiceTests(snapName string) (teardown func(), err error) {
 	if err = WaitPlatformOnline(nil); err != nil {
 		teardown()
 		return
-	}
-
-	// TODO: remove this patch which is for device services
-	if strings.Contains(snapName, "device-") {
-		err = InjectDevicesAndProfilesDirConfig(strings.TrimPrefix(snapName, "edgex-"))
-		if err != nil {
-			log.Fatalf("Failed to inject devices/profiles dir into config: %s", err)
-		}
 	}
 
 	return


### PR DESCRIPTION
Reverting https://github.com/canonical/edgex-snap-testing/pull/179 since upstream has decided to add the device profile paths locally, making it possible to override them via the snapcraft file.