### PR TITLE
Start platform snap after installation

### DIFF
--- a/test/suites/edgex-config-provider/main_test.go
+++ b/test/suites/edgex-config-provider/main_test.go
@@ -90,6 +90,9 @@ func setup() (teardown func(), err error) {
 		return
 	}
 
+	utils.SnapStart(nil, platformSnap)
+
+	// make sure all services are online before starting the tests
 	if err = utils.WaitPlatformOnline(nil); err != nil {
 		teardown()
 		return

--- a/test/suites/edgex-no-sec/main_test.go
+++ b/test/suites/edgex-no-sec/main_test.go
@@ -8,9 +8,7 @@ import (
 	"time"
 )
 
-const (
-	platformSnap = "edgexfoundry"
-)
+const platformSnap = "edgexfoundry"
 
 func platformPortsNoSec() []string {
 	return []string{
@@ -71,6 +69,8 @@ func setup() (teardown func(), err error) {
 
 	// turn security off
 	utils.SnapSet(nil, platformSnap, "security", "false")
+
+	utils.SnapStart(nil, platformSnap)
 
 	// make sure all services are online before starting the tests
 	if err = utils.WaitServiceOnline(nil, 180, platformPortsNoSec()...); err != nil {

--- a/test/suites/edgexfoundry/main_test.go
+++ b/test/suites/edgexfoundry/main_test.go
@@ -76,6 +76,8 @@ func setup() (teardown func(), err error) {
 		return
 	}
 
+	utils.SnapStart(nil, platformSnap)
+
 	// make sure all services are online before starting the tests
 	if err = utils.WaitPlatformOnline(nil); err != nil {
 		teardown()

--- a/test/suites/edgexfoundry/refresh/refresh_test.go
+++ b/test/suites/edgexfoundry/refresh/refresh_test.go
@@ -5,9 +5,7 @@ import (
 	"testing"
 )
 
-const (
-	platformSnap = "edgexfoundry"
-)
+const platformSnap = "edgexfoundry"
 
 func TestCommon(t *testing.T) {
 	utils.TestRefresh(t, platformSnap)

--- a/test/suites/ekuiper/main_test.go
+++ b/test/suites/ekuiper/main_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 const (
+	platformSnap = "edgexfoundry"
+
 	ekuiperSnap       = "edgex-ekuiper"
 	ekuiperApp        = "ekuiper"
 	ekuiperRestfulApi = "ekuiper/rest-api"
@@ -65,7 +67,7 @@ func setup() (teardown func(), err error) {
 	log.Println("[CLEAN]")
 	utils.SnapRemove(nil,
 		ekuiperSnap,
-		"edgexfoundry",
+		platformSnap,
 		deviceVirtualSnap,
 	)
 
@@ -76,14 +78,14 @@ func setup() (teardown func(), err error) {
 		log.Println("[TEARDOWN]")
 
 		utils.SnapDumpLogs(nil, start, ekuiperSnap)
-		utils.SnapDumpLogs(nil, start, "edgexfoundry")
+		utils.SnapDumpLogs(nil, start, platformSnap)
 		utils.SnapDumpLogs(nil, start, deviceVirtualSnap)
 
 		log.Println("Removing installed snap:", !utils.SkipTeardownRemoval)
 		if !utils.SkipTeardownRemoval {
 			utils.SnapRemove(nil,
 				ekuiperSnap,
-				"edgexfoundry",
+				platformSnap,
 				deviceVirtualSnap,
 			)
 		}
@@ -101,7 +103,7 @@ func setup() (teardown func(), err error) {
 		return
 	}
 
-	if err = utils.SnapInstallFromStore(nil, "edgexfoundry", utils.PlatformChannel); err != nil {
+	if err = utils.SnapInstallFromStore(nil, platformSnap, utils.PlatformChannel); err != nil {
 		teardown()
 		return
 	}
@@ -119,6 +121,8 @@ func setup() (teardown func(), err error) {
 			return
 		}
 	}
+
+	utils.SnapStart(nil, platformSnap)
 
 	// make sure all services are online before starting the tests
 	if err = utils.WaitPlatformOnline(nil); err != nil {

--- a/test/utils/setup.go
+++ b/test/utils/setup.go
@@ -5,13 +5,15 @@ import (
 	"time"
 )
 
+const platformSnap = "edgexfoundry"
+
 // SetupServiceTests setup up the environment for testing
 // It returns a teardown function to be called at the end of the tests
 func SetupServiceTests(snapName string) (teardown func(), err error) {
 	log.Println("[CLEAN]")
 	SnapRemove(nil,
 		snapName,
-		"edgexfoundry",
+		platformSnap,
 	)
 
 	log.Println("[SETUP]")
@@ -20,13 +22,13 @@ func SetupServiceTests(snapName string) (teardown func(), err error) {
 	teardown = func() {
 		log.Println("[TEARDOWN]")
 		SnapDumpLogs(nil, start, snapName)
-		SnapDumpLogs(nil, start, "edgexfoundry")
+		SnapDumpLogs(nil, start, platformSnap)
 
 		log.Println("Removing installed snap:", !SkipTeardownRemoval)
 		if !SkipTeardownRemoval {
 			SnapRemove(nil,
 				snapName,
-				"edgexfoundry",
+				platformSnap,
 			)
 		}
 	}
@@ -43,7 +45,7 @@ func SetupServiceTests(snapName string) (teardown func(), err error) {
 		return
 	}
 
-	if err = SnapInstallFromStore(nil, "edgexfoundry", PlatformChannel); err != nil {
+	if err = SnapInstallFromStore(nil, platformSnap, PlatformChannel); err != nil {
 		teardown()
 		return
 	}
@@ -56,6 +58,8 @@ func SetupServiceTests(snapName string) (teardown func(), err error) {
 			return
 		}
 	}
+
+	SnapStart(nil, platformSnap)
 
 	// make sure all services are online before starting the tests
 	if err = WaitPlatformOnline(nil); err != nil {


### PR DESCRIPTION
This PR incorporates the change of removing `autostart=true` in platform snap in https://github.com/edgexfoundry/edgex-go/pull/4552. The test passed on channel `latest/edge/pr-4552` successfully:
```
$ PLATFORM_CHANNEL=latest/edge/pr-4552 go test -v ./test/suites/edgexfoundry
2023/05/04 13:48:13 [CLEAN]
2023/05/04 13:48:13 [exec] sudo snap remove --purge edgexfoundry
[sudo] password for mengyi: 
2023/05/04 13:48:17 [stdout] 2023-05-04T13:48:17+02:00 INFO Waiting for "snap.edgexfoundry.core-metadata.service" to stop.
2023/05/04 13:48:18 [stdout] 2023-05-04T13:48:18+02:00 INFO Waiting for "snap.edgexfoundry.consul.service" to stop.
2023/05/04 13:48:20 [stdout] 2023-05-04T13:48:20+02:00 INFO Waiting for "snap.edgexfoundry.core-data.service" to stop.
2023/05/04 13:48:32 [stdout] 2023-05-04T13:48:32+02:00 INFO Waiting for "snap.edgexfoundry.kong-daemon.service" to stop.
2023/05/04 13:48:51 [stdout] edgexfoundry removed
2023/05/04 13:48:51 [SETUP]
2023/05/04 13:48:51 [exec] sudo snap install edgexfoundry --channel=latest/edge/pr-4552
2023/05/04 13:51:39 [stdout] edgexfoundry (edge/pr-4552) 3.0.0-dev.13 from Canonical** installed
2023/05/04 13:51:39 [exec] sudo snap start --enable edgexfoundry
2023/05/04 13:53:14 [stdout] Started.
2023/05/04 13:53:14 Retry 1/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command), 8200 (vault), 8500 (consul), 6379 (redis), 8000 (nginx(http)), 59842 (security-proxy-auth), 8443 (nginx(https))
2023/05/04 13:53:15 Retry 2/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command), 59842 (security-proxy-auth)
2023/05/04 13:53:16 Retry 3/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:17 Retry 4/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:18 Retry 5/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:19 Retry 6/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:20 Retry 7/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:21 Retry 8/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:22 Retry 9/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:23 Retry 10/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:24 Retry 11/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:25 Retry 12/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:26 Retry 13/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:27 Retry 14/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:28 Retry 15/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:29 Retry 16/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:30 Retry 17/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:31 Retry 18/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:32 Retry 19/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:33 Retry 20/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:34 Retry 21/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:35 Retry 22/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:36 Retry 23/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:37 Retry 24/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:38 Retry 25/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:39 Retry 26/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:40 Retry 27/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:41 Retry 28/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:42 Retry 29/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:43 Retry 30/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:44 Retry 31/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:45 Retry 32/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:46 Retry 33/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:47 Retry 34/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:48 Retry 35/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:49 Retry 36/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:50 Retry 37/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:51 Retry 38/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:52 Retry 39/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:53 Retry 40/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:54 Retry 41/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:55 Retry 42/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:56 Retry 43/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:57 Retry 44/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:58 Retry 45/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:53:59 Retry 46/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:54:00 Retry 47/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:54:01 Retry 48/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:54:02 Retry 49/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:54:03 Retry 50/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:54:04 Retry 51/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:54:05 Retry 52/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:54:06 Retry 53/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:54:07 Retry 54/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:54:08 Retry 55/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:54:09 Retry 56/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:54:10 Retry 57/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:54:11 Retry 58/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:54:12 Retry 59/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:54:13 Retry 60/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:54:14 Retry 61/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:54:15 Retry 62/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:54:16 Retry 63/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:54:17 Retry 64/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:54:18 Retry 65/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:54:19 Retry 66/180: Waiting for ports: 59881 (core-metadata), 59882 (core-command)
2023/05/04 13:54:20 Retry 67/180: Waiting for ports: 59882 (core-command)
2023/05/04 13:54:20 [exec] sudo snap start --enable edgexfoundry.support-scheduler
2023/05/04 13:54:20 [stdout] Started.
2023/05/04 13:54:20 Retry 1/60: Waiting for ports: 59861 (support-scheduler)
2023/05/04 13:54:21 Retry 2/60: Waiting for ports: 59861 (support-scheduler)
2023/05/04 13:54:22 Retry 3/60: Waiting for ports: 59861 (support-scheduler)
2023/05/04 13:54:23 Retry 4/60: Waiting for ports: 59861 (support-scheduler)
=== RUN   TestChangeStartupMsg_app
    exec.go:19: [exec] sudo snap set edgexfoundry apps.support-scheduler.config.edgex-config-provider='none'
    exec.go:19: [exec] sudo snap set edgexfoundry apps.support-scheduler.config.edgex-common-config='./config/core-common-config-bootstrapper/res/configuration.yaml'
    config_test.go:26: Set and verify new startup message: snap-testing (app)
    exec.go:19: [exec] sudo snap set edgexfoundry apps.support-scheduler.config.service-startupmsg='snap-testing (app)'
    exec.go:19: [exec] sudo snap restart edgexfoundry.support-scheduler
    exec.go:101: [stdout] 2023-05-04T13:54:26+02:00 INFO Waiting for "snap.edgexfoundry.support-scheduler.service" to stop.
    exec.go:101: [stdout] Restarted.
    net.go:144: Retry 1/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command), 8200 (vault), 8500 (consul), 6379 (redis), 8000 (nginx(http)), 59842 (security-proxy-auth), 8443 (nginx(https))
    config.go:220: Retry 1/10: Waiting for expected content in logs: msg="snap-testing (app)"
    exec.go:19: [exec] sudo journalctl --since "2023-05-04 13:54:24" --no-pager | grep "edgexfoundry.support-scheduler"|| true
    config.go:225: Found expected content in logs: msg="snap-testing (app)"
    config_test.go:34: Unset and check default message
    exec.go:19: [exec] sudo snap unset edgexfoundry apps.support-scheduler.config.service-startupmsg
    exec.go:19: [exec] sudo snap restart edgexfoundry.support-scheduler
    exec.go:101: [stdout] Restarted.
    net.go:144: Retry 1/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command), 8200 (vault), 8500 (consul), 6379 (redis), 8000 (nginx(http)), 59842 (security-proxy-auth), 8443 (nginx(https))
    config.go:220: Retry 1/10: Waiting for expected content in logs: msg="This is the Support Scheduler Microservice"
    exec.go:19: [exec] sudo journalctl --since "2023-05-04 13:54:31" --no-pager | grep "edgexfoundry.support-scheduler"|| true
    config.go:225: Found expected content in logs: msg="This is the Support Scheduler Microservice"
    exec.go:19: [exec] sudo snap unset edgexfoundry apps.support-scheduler.config.service-startupmsg
    exec.go:19: [exec] sudo snap restart edgexfoundry.support-scheduler
    exec.go:101: [stdout] Restarted.
--- PASS: TestChangeStartupMsg_app (8.98s)
=== RUN   TestChangeStartupMsg_global
    exec.go:19: [exec] sudo snap set edgexfoundry apps.support-scheduler.config.edgex-config-provider='none'
    exec.go:19: [exec] sudo snap set edgexfoundry apps.support-scheduler.config.edgex-common-config='./config/core-common-config-bootstrapper/res/configuration.yaml'
    config_test.go:55: Set and verify new startup message: snap-testing (global)
    exec.go:19: [exec] sudo snap set edgexfoundry config.service-startupmsg='snap-testing (global)'
    exec.go:19: [exec] sudo snap restart edgexfoundry.support-scheduler
    exec.go:101: [stdout] Restarted.
    net.go:144: Retry 1/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command), 8200 (vault), 8500 (consul), 6379 (redis), 8000 (nginx(http)), 59842 (security-proxy-auth), 8443 (nginx(https))
    config.go:220: Retry 1/10: Waiting for expected content in logs: msg="snap-testing (global)"
    exec.go:19: [exec] sudo journalctl --since "2023-05-04 13:54:33" --no-pager | grep "edgexfoundry.support-scheduler"|| true
    config.go:225: Found expected content in logs: msg="snap-testing (global)"
    config_test.go:63: Unset and check default message
    exec.go:19: [exec] sudo snap unset edgexfoundry config.service-startupmsg
    exec.go:19: [exec] sudo snap restart edgexfoundry.support-scheduler
    exec.go:101: [stdout] Restarted.
    net.go:144: Retry 1/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command), 8200 (vault), 8500 (consul), 6379 (redis), 8000 (nginx(http)), 59842 (security-proxy-auth), 8443 (nginx(https))
    config.go:220: Retry 1/10: Waiting for expected content in logs: msg="This is the Support Scheduler Microservice"
    exec.go:19: [exec] sudo journalctl --since "2023-05-04 13:54:35" --no-pager | grep "edgexfoundry.support-scheduler"|| true
    config.go:225: Found expected content in logs: msg="This is the Support Scheduler Microservice"
    exec.go:19: [exec] sudo snap unset edgexfoundry config.service-startupmsg
    exec.go:19: [exec] sudo snap restart edgexfoundry.support-scheduler
    exec.go:101: [stdout] 2023-05-04T13:54:39+02:00 INFO Waiting for "snap.edgexfoundry.support-scheduler.service" to stop.
    exec.go:101: [stdout] Restarted.
--- PASS: TestChangeStartupMsg_global (6.40s)
=== RUN   TestChangeStartupMsg_mixedGlobalApp
    exec.go:19: [exec] sudo snap set edgexfoundry apps.support-scheduler.config.edgex-config-provider='none'
    exec.go:19: [exec] sudo snap set edgexfoundry apps.support-scheduler.config.edgex-common-config='./config/core-common-config-bootstrapper/res/configuration.yaml'
    config_test.go:87: Set local and global startup messages and verify that local has taken precedence
    exec.go:19: [exec] sudo snap set edgexfoundry apps.support-scheduler.config.service-startupmsg='snap-testing (app specific)'
    exec.go:19: [exec] sudo snap set edgexfoundry config.service-startupmsg='snap-testing (global override)'
    exec.go:19: [exec] sudo snap restart edgexfoundry.support-scheduler
    exec.go:101: [stdout] Restarted.
    net.go:144: Retry 1/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command), 8200 (vault), 8500 (consul), 6379 (redis), 8000 (nginx(http)), 59842 (security-proxy-auth), 8443 (nginx(https))
    config.go:220: Retry 1/10: Waiting for expected content in logs: msg="snap-testing (app specific)"
    exec.go:19: [exec] sudo journalctl --since "2023-05-04 13:54:40" --no-pager | grep "edgexfoundry.support-scheduler"|| true
    config.go:225: Found expected content in logs: msg="snap-testing (app specific)"
    config_test.go:96: Unset and check default message
    exec.go:19: [exec] sudo snap unset edgexfoundry apps.support-scheduler.config.service-startupmsg
    exec.go:19: [exec] sudo snap unset edgexfoundry config.service-startupmsg
    exec.go:19: [exec] sudo snap restart edgexfoundry.support-scheduler
    exec.go:101: [stdout] Restarted.
    net.go:144: Retry 1/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command), 8200 (vault), 8500 (consul), 6379 (redis), 8000 (nginx(http)), 59842 (security-proxy-auth), 8443 (nginx(https))
    config.go:220: Retry 1/10: Waiting for expected content in logs: msg="This is the Support Scheduler Microservice"
    exec.go:19: [exec] sudo journalctl --since "2023-05-04 13:54:42" --no-pager | grep "edgexfoundry.support-scheduler"|| true
    config.go:225: Found expected content in logs: msg="This is the Support Scheduler Microservice"
    exec.go:19: [exec] sudo snap unset edgexfoundry config.service-startupmsg
    exec.go:19: [exec] sudo snap restart edgexfoundry.support-scheduler
    exec.go:101: [stdout] Restarted.
--- PASS: TestChangeStartupMsg_mixedGlobalApp (6.99s)
=== RUN   TestCommon
=== RUN   TestCommon/config
=== RUN   TestCommon/config/autostart
=== RUN   TestCommon/net
=== RUN   TestCommon/net/ports_open
    net.go:144: Retry 1/60: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command), 8200 (vault), 8500 (consul), 6379 (redis), 8000 (nginx(http)), 59842 (security-proxy-auth), 8443 (nginx(https))
=== CONT  TestCommon/net
    net.go:144: Retry 1/60: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command), 8200 (vault), 8500 (consul), 6379 (redis), 8000 (nginx(http)), 59842 (security-proxy-auth)
=== RUN   TestCommon/net/ports_not_listening_on_all_interfaces
    exec.go:19: [exec] sudo lsof -nPi :59880 || true
    net.go:264: Looking for '*:59880 (LISTEN)'
    exec.go:19: [exec] sudo lsof -nPi :59881 || true
    net.go:264: Looking for '*:59881 (LISTEN)'
    exec.go:19: [exec] sudo lsof -nPi :59882 || true
    net.go:264: Looking for '*:59882 (LISTEN)'
    exec.go:19: [exec] sudo lsof -nPi :8200 || true
    net.go:264: Looking for '*:8200 (LISTEN)'
    exec.go:19: [exec] sudo lsof -nPi :8500 || true
    net.go:264: Looking for '*:8500 (LISTEN)'
    exec.go:19: [exec] sudo lsof -nPi :6379 || true
    net.go:264: Looking for '*:6379 (LISTEN)'
    exec.go:19: [exec] sudo lsof -nPi :8000 || true
    net.go:264: Looking for '*:8000 (LISTEN)'
    exec.go:19: [exec] sudo lsof -nPi :59842 || true
    net.go:264: Looking for '*:59842 (LISTEN)'
=== RUN   TestCommon/net/ports_listening_on_localhost
    exec.go:19: [exec] sudo lsof -nPi :59880 || true
    net.go:264: Looking for '127.0.0.1:59880 (LISTEN)'
    exec.go:19: [exec] sudo lsof -nPi :59881 || true
    net.go:264: Looking for '127.0.0.1:59881 (LISTEN)'
    exec.go:19: [exec] sudo lsof -nPi :59882 || true
    net.go:264: Looking for '127.0.0.1:59882 (LISTEN)'
    exec.go:19: [exec] sudo lsof -nPi :8200 || true
    net.go:264: Looking for '127.0.0.1:8200 (LISTEN)'
    exec.go:19: [exec] sudo lsof -nPi :8500 || true
    net.go:264: Looking for '127.0.0.1:8500 (LISTEN)'
    exec.go:19: [exec] sudo lsof -nPi :6379 || true
    net.go:264: Looking for '127.0.0.1:6379 (LISTEN)'
    exec.go:19: [exec] sudo lsof -nPi :8000 || true
    net.go:264: Looking for '127.0.0.1:8000 (LISTEN)'
    exec.go:19: [exec] sudo lsof -nPi :59842 || true
    net.go:264: Looking for '127.0.0.1:59842 (LISTEN)'
=== RUN   TestCommon/packaging
=== RUN   TestCommon/packaging/semantic_snap_version
    exec.go:19: [exec] snap info edgexfoundry | grep installed | awk '{print $2}'
    exec.go:101: [stdout] 3.0.0-dev.13
--- PASS: TestCommon (2.54s)
    --- PASS: TestCommon/config (0.00s)
        --- PASS: TestCommon/config/autostart (0.00s)
    --- PASS: TestCommon/net (2.09s)
        --- PASS: TestCommon/net/ports_open (0.00s)
        --- PASS: TestCommon/net/ports_not_listening_on_all_interfaces (1.07s)
        --- PASS: TestCommon/net/ports_listening_on_localhost (1.02s)
    --- PASS: TestCommon/packaging (0.45s)
        --- PASS: TestCommon/packaging/semantic_snap_version (0.45s)
PASS
2023/05/04 13:54:48 [TEARDOWN]
2023/05/04 13:54:48 [exec] (sudo journalctl --since "2023-05-04 13:48:51" --no-pager | grep "edgexfoundry"|| true) > edgexfoundry.log
Wrote snap logs to /home/mengyi/Desktop/start-edgexfoundry/edgex-snap-testing/test/suites/edgexfoundry/edgexfoundry.log
2023/05/04 13:54:48 Removing installed snap: true
2023/05/04 13:54:48 [exec] sudo snap remove --purge edgexfoundry
2023/05/04 13:54:50 [stdout] 2023-05-04T13:54:49+02:00 INFO Waiting for "snap.edgexfoundry.consul.service" to stop.
2023/05/04 13:54:51 [stdout] 2023-05-04T13:54:51+02:00 INFO Waiting for "snap.edgexfoundry.core-data.service" to stop.
2023/05/04 13:54:52 [stdout] 2023-05-04T13:54:52+02:00 INFO Waiting for "snap.edgexfoundry.core-metadata.service" to stop.
2023/05/04 13:55:04 [stdout] edgexfoundry removed
ok  	edgex-snap-testing/test/suites/edgexfoundry	411.519s
```
