### PR TITLE
Start only non-sec services in no-sec tests

### DIFF
--- a/test/suites/edgex-no-sec/main_test.go
+++ b/test/suites/edgex-no-sec/main_test.go
@@ -69,8 +69,22 @@ func setup() (teardown func(), err error) {
 
 	// disable security - this sets autostart of security services to false
 	utils.SnapSet(nil, platformSnap, "security", "false")
-	// enable autostart globally to start all services apart from security services that are explicitly disabled
+
+	// enable autostart globally to start all services apart from security services that are explicitly disabled:
 	utils.SnapSet(nil, platformSnap, "autostart", "true")
+	// The above is equivalent to starting non-security services manually:
+	// utils.SnapStart(nil, func() (names []string) {
+	// 	nonSecServices := []string{
+	// 		"consul", "redis",
+	// 		"core-common-config-bootstrapper",
+	// 		"core-data", "core-metadata", "core-command",
+	// 		"support-scheduler", "support-notifications",
+	// 	}
+	// 	for _, s := range nonSecServices {
+	// 		names = append(names, "edgexfoundry."+s)
+	// 	}
+	// 	return
+	// }()...)
 
 	// make sure all services are online before starting the tests
 	if err = utils.WaitServiceOnline(nil, 180, platformPortsNoSec()...); err != nil {

--- a/test/suites/edgex-no-sec/main_test.go
+++ b/test/suites/edgex-no-sec/main_test.go
@@ -67,10 +67,10 @@ func setup() (teardown func(), err error) {
 		return
 	}
 
-	// turn security off
+	// disable security - this sets autostart of security services to false
 	utils.SnapSet(nil, platformSnap, "security", "false")
-
-	utils.SnapStart(nil, platformSnap)
+	// enable autostart globally to start all services apart from security services that are explicitly disabled
+	utils.SnapSet(nil, platformSnap, "autostart", "true")
 
 	// make sure all services are online before starting the tests
 	if err = utils.WaitServiceOnline(nil, 180, platformPortsNoSec()...); err != nil {


### PR DESCRIPTION
The `security=false` option was used to disable security and re-start all the services. This relied on the default `autostart=true` to start the non-sec services after stopping all. See https://github.com/edgexfoundry/edgex-go/blob/ce5d24036f637d84b811de065aa37bd3eaf3c7fe/snap/local/helper-go/configure.go#L98-L111

That logic no longer fully works by default because the service are no longer started by default as of https://github.com/edgexfoundry/edgex-go/pull/4552

Manually starting services with snap start will also start the unwanted security services.

This PR uses the following workaround:
```
sudo snap set edgexfoundry security=false
sudo snap set edgexfoundry autostart=true
```