### PR TITLE
Add LOCAL_PLATFORM_SNAP and LOCAL_SERVICE_SNAP environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,21 @@ Full config test:
 FULL_CONFIG_TEST=true go test -v -failfast -count 1 ./test/suites/device-mqtt
 ```
 
-Testing with a local snap:
+Testing with a local platform snap:
 ```bash
-LOCAL_SNAP="edgex-device-mqtt_2.0.1-dev.15_amd64.snap" go test -v -failfast -count 1 ./test/suites/device-mqtt
+LOCAL_PLATFORM_SNAP="edgexfoundry_3.1.0-dev.3_amd64.snap" \
+go test -v -failfast -count 1 ./test/suites/edgexfoundry
+```
+Testing with a local service snap:
+```bash
+LOCAL_SERVICE_SNAP="edgex-device-mqtt_2.0.1-dev.15_amd64.snap" \
+go test -v -failfast -count 1 ./test/suites/device-mqtt
+```
+Testing with local platform and service snaps:
+```bash
+LOCAL_PLATFORM_SNAP="edgexfoundry_3.1.0-dev.3_amd64.snap" \
+LOCAL_SERVICE_SNAP="edgex-device-mqtt_2.0.1-dev.15_amd64.snap" \
+go test -v -failfast -count 1 ./test/suites/device-mqtt
 ```
 
 Test with skipping the removal of snaps during teardown:

--- a/test/action.yml
+++ b/test/action.yml
@@ -60,8 +60,8 @@ runs:
     - shell: bash
       working-directory: ${{github.action_path}}
       env:
-        LOCAL_PLATFORM_SNAP: ${{ inputs.snap == 'edgexfoundry' && steps.path.outputs.local_snap || ' ' }}
-        LOCAL_SERVICE_SNAP: ${{ inputs.snap != 'edgexfoundry' && steps.path.outputs.local_snap || ' ' }}
+        LOCAL_PLATFORM_SNAP: ${{ inputs.snap == 'edgexfoundry' && steps.path.outputs.local_snap || '' }}
+        LOCAL_SERVICE_SNAP: ${{ inputs.snap != 'edgexfoundry' && steps.path.outputs.local_snap || '' }}
         PLATFORM_CHANNEL: ${{inputs.platform_channel}}
         SERVICE_CHANNEL: ${{inputs.channel}}
         FULL_CONFIG_TEST: ${{inputs.full_config_test}}

--- a/test/action.yml
+++ b/test/action.yml
@@ -60,8 +60,8 @@ runs:
     - shell: bash
       working-directory: ${{github.action_path}}
       env:
-        LOCAL_PLATFORM_SNAP: ${{ inputs.snap == 'edgexfoundry' && steps.path.outputs.local_snap || '' }}
-        LOCAL_SERVICE_SNAP: ${{ inputs.snap != 'edgexfoundry' && steps.path.outputs.local_snap || '' }}
+        LOCAL_PLATFORM_SNAP: ${{ inputs.name == 'edgexfoundry' && steps.path.outputs.local_snap || '' }}
+        LOCAL_SERVICE_SNAP: ${{ inputs.name != 'edgexfoundry' && steps.path.outputs.local_snap || '' }}
         PLATFORM_CHANNEL: ${{inputs.platform_channel}}
         SERVICE_CHANNEL: ${{inputs.channel}}
         FULL_CONFIG_TEST: ${{inputs.full_config_test}}

--- a/test/action.yml
+++ b/test/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: Name of the testing suite
     required: true
   snap:
-    description: Relative path to local snap
+    description: Relative path to local platform or service snap
     required: false
   channel:
     description: |
@@ -60,7 +60,8 @@ runs:
     - shell: bash
       working-directory: ${{github.action_path}}
       env:
-        LOCAL_SNAP: ${{steps.path.outputs.local_snap}}
+        LOCAL_PLATFORM_SNAP: ${{ inputs.snap == 'edgexfoundry' && steps.path.outputs.local_snap || ' ' }}
+        LOCAL_SERVICE_SNAP: ${{ inputs.snap != 'edgexfoundry' && steps.path.outputs.local_snap || ' ' }}
         PLATFORM_CHANNEL: ${{inputs.platform_channel}}
         SERVICE_CHANNEL: ${{inputs.channel}}
         FULL_CONFIG_TEST: ${{inputs.full_config_test}}

--- a/test/suites/edgex-config-provider/main_test.go
+++ b/test/suites/edgex-config-provider/main_test.go
@@ -59,8 +59,8 @@ func setup() (teardown func(), err error) {
 	}
 
 	// install the provider
-	if utils.LocalSnap() {
-		if err = utils.SnapInstallFromFile(nil, utils.LocalSnapPath); err != nil {
+	if utils.LocalServiceSnap() {
+		if err = utils.SnapInstallFromFile(nil, utils.LocalServiceSnapPath); err != nil {
 			teardown()
 			return
 		}
@@ -85,7 +85,12 @@ func setup() (teardown func(), err error) {
 		}
 	}
 
-	if err = utils.SnapInstallFromStore(nil, platformSnap, utils.PlatformChannel); err != nil {
+	if utils.LocalPlatformSnap() {
+		err = utils.SnapInstallFromFile(nil, utils.LocalPlatformSnapPath)
+	} else {
+		err = utils.SnapInstallFromStore(nil, platformSnap, utils.PlatformChannel)
+	}
+	if err != nil {
 		teardown()
 		return
 	}

--- a/test/suites/edgex-no-sec/main_test.go
+++ b/test/suites/edgex-no-sec/main_test.go
@@ -57,8 +57,8 @@ func setup() (teardown func(), err error) {
 		}
 	}
 
-	if utils.LocalSnap() {
-		err = utils.SnapInstallFromFile(nil, utils.LocalSnapPath)
+	if utils.LocalPlatformSnap() {
+		err = utils.SnapInstallFromFile(nil, utils.LocalPlatformSnapPath)
 	} else {
 		err = utils.SnapInstallFromStore(nil, platformSnap, utils.PlatformChannel)
 	}

--- a/test/suites/edgexfoundry/main_test.go
+++ b/test/suites/edgexfoundry/main_test.go
@@ -65,8 +65,8 @@ func setup() (teardown func(), err error) {
 		}
 	}
 
-	if utils.LocalSnap() {
-		err = utils.SnapInstallFromFile(nil, utils.LocalSnapPath)
+	if utils.LocalPlatformSnap() {
+		err = utils.SnapInstallFromFile(nil, utils.LocalPlatformSnapPath)
 	} else {
 		err = utils.SnapInstallFromStore(nil, platformSnap, utils.PlatformChannel)
 	}

--- a/test/suites/ekuiper/main_test.go
+++ b/test/suites/ekuiper/main_test.go
@@ -93,8 +93,8 @@ func setup() (teardown func(), err error) {
 
 	// install the ekuiper snap before edgexfoundry
 	// to catch build error sooner and stop
-	if utils.LocalSnap() {
-		err = utils.SnapInstallFromFile(nil, utils.LocalSnapPath)
+	if utils.LocalServiceSnap() {
+		err = utils.SnapInstallFromFile(nil, utils.LocalServiceSnapPath)
 	} else {
 		err = utils.SnapInstallFromStore(nil, ekuiperSnap, utils.ServiceChannel)
 	}
@@ -103,7 +103,12 @@ func setup() (teardown func(), err error) {
 		return
 	}
 
-	if err = utils.SnapInstallFromStore(nil, platformSnap, utils.PlatformChannel); err != nil {
+	if utils.LocalPlatformSnap() {
+		err = utils.SnapInstallFromFile(nil, utils.LocalPlatformSnapPath)
+	} else {
+		err = utils.SnapInstallFromStore(nil, platformSnap, utils.PlatformChannel)
+	}
+	if err != nil {
 		teardown()
 		return
 	}
@@ -115,7 +120,7 @@ func setup() (teardown func(), err error) {
 
 	// for local build, the interface isn't auto-connected.
 	// connect manually
-	if utils.LocalSnap() {
+	if utils.LocalServiceSnap() {
 		if err = utils.SnapConnectSecretstoreToken(nil, ekuiperSnap); err != nil {
 			teardown()
 			return

--- a/test/suites/ui/main_test.go
+++ b/test/suites/ui/main_test.go
@@ -54,8 +54,8 @@ func setup() (teardown func(), err error) {
 		}
 	}
 
-	if utils.LocalSnap() {
-		err = utils.SnapInstallFromFile(nil, utils.LocalSnapPath)
+	if utils.LocalServiceSnap() {
+		err = utils.SnapInstallFromFile(nil, utils.LocalServiceSnapPath)
 	} else {
 		err = utils.SnapInstallFromStore(nil, uiSnap, utils.ServiceChannel)
 	}

--- a/test/utils/env.go
+++ b/test/utils/env.go
@@ -8,20 +8,23 @@ import (
 const (
 	// environment variables
 	// used to override defaults
-	platformChannelEnv     = "PLATFORM_CHANNEL"      // channel/revision of the edgexfoundry snap (has default)
-	serviceChannelEnv      = "SERVICE_CHANNEL"       // channel/revision of the service snap (has default)
-	localSnapEnv           = "LOCAL_SNAP"            // path to local snap to be tested instead of downloading from a channel
+	platformChannelEnv   = "PLATFORM_CHANNEL"    // channel/revision of the edgexfoundry snap (has default)
+	serviceChannelEnv    = "SERVICE_CHANNEL"     // channel/revision of the service snap (has default)
+	localPlatformSnapEnv = "LOCAL_PLATFORM_SNAP" // path to local platform snap to be tested instead of downloading from a channel
+	localServiceSnapEnv  = "LOCAL_SERVICE_SNAP"  // path to local service snap to be tested instead of downloading from a channel
+
 	fullConfigTestEnv      = "FULL_CONFIG_TEST"      // toggle full config tests (has default)
 	skipTeardownRemovalEnv = "SKIP_TEARDOWN_REMOVAL" // skip the removal of snaps during teardown
 )
 
 var (
 	// global defaults
-	PlatformChannel     = "latest/edge"
-	ServiceChannel      = "latest/edge"
-	LocalSnapPath       = ""
-	FullConfigTest      = false
-	SkipTeardownRemoval = false
+	PlatformChannel       = "latest/edge"
+	ServiceChannel        = "latest/edge"
+	LocalPlatformSnapPath = ""
+	LocalServiceSnapPath  = ""
+	FullConfigTest        = false
+	SkipTeardownRemoval   = false
 )
 
 func init() {
@@ -33,8 +36,12 @@ func init() {
 		ServiceChannel = v
 	}
 
-	if v := os.Getenv(localSnapEnv); v != "" {
-		LocalSnapPath = v
+	if v := os.Getenv(localPlatformSnapEnv); v != "" {
+		LocalPlatformSnapPath = v
+	}
+
+	if v := os.Getenv(localServiceSnapEnv); v != "" {
+		LocalServiceSnapPath = v
 	}
 
 	if v := os.Getenv(fullConfigTestEnv); v != "" {

--- a/test/utils/refresh.go
+++ b/test/utils/refresh.go
@@ -10,7 +10,7 @@ import (
 // TestRefresh tests an EdgeX upgrade using snap refresh
 func TestRefresh(t *testing.T, snapName string) {
 	t.Run("refresh", func(t *testing.T) {
-		if LocalSnap() {
+		if LocalPlatformSnap() {
 			t.Skip("Skip refresh for local snap build")
 		}
 

--- a/test/utils/setup.go
+++ b/test/utils/setup.go
@@ -63,7 +63,7 @@ func SetupServiceTests(snapName string) (teardown func(), err error) {
 
 	// for local build, the interface isn't auto-connected.
 	// connect manually
-	if LocalServiceSnap() || LocalPlatformSnap {
+	if LocalServiceSnap() || LocalPlatformSnap() {
 		if err = SnapConnectSecretstoreToken(nil, snapName); err != nil {
 			teardown()
 			return

--- a/test/utils/setup.go
+++ b/test/utils/setup.go
@@ -35,8 +35,8 @@ func SetupServiceTests(snapName string) (teardown func(), err error) {
 
 	// install the device/app service snap before edgexfoundry
 	// to catch build error sooner and stop
-	if LocalSnap() {
-		err = SnapInstallFromFile(nil, LocalSnapPath)
+	if LocalServiceSnap() {
+		err = SnapInstallFromFile(nil, LocalServiceSnapPath)
 	} else {
 		err = SnapInstallFromStore(nil, snapName, ServiceChannel)
 	}
@@ -50,9 +50,20 @@ func SetupServiceTests(snapName string) (teardown func(), err error) {
 		return
 	}
 
+	// install the edgexfoundry platform snap
+	if LocalPlatformSnap() {
+		err = SnapInstallFromFile(nil, LocalPlatformSnapPath)
+	} else {
+		err = SnapInstallFromStore(nil, snapName, PlatformChannel)
+	}
+	if err != nil {
+		teardown()
+		return
+	}
+
 	// for local build, the interface isn't auto-connected.
 	// connect manually
-	if LocalSnap() {
+	if LocalServiceSnap() || LocalPlatformSnap {
 		if err = SnapConnectSecretstoreToken(nil, snapName); err != nil {
 			teardown()
 			return

--- a/test/utils/snap.go
+++ b/test/utils/snap.go
@@ -210,6 +210,10 @@ func SnapServicesActive(t *testing.T, name string) bool {
 	return strings.TrimSpace(out) == "active"
 }
 
-func LocalSnap() bool {
-	return LocalSnapPath != ""
+func LocalPlatformSnap() bool {
+	return LocalPlatformSnapPath != ""
+}
+
+func LocalServiceSnap() bool {
+	return LocalServiceSnapPath != ""
 }


### PR DESCRIPTION
This PR will resolve #215

### Test
```
$ LOCAL_PLATFORM_SNAP="edgexfoundry_3.1.0-dev.3_amd64.snap" \
go test -v -failfast -count 1 ./test/suites/edgexfoundry
[exec] sudo snap install --dangerous edgexfoundry_3.1.0-dev.3_amd64.snap
...
PASS
```
```
$ LOCAL_SERVICE_SNAP=edgex-device-mqtt_3.1.0-dev.2_amd64.snap \
go test -v -failfast -count 1 ./test/suites/device-mqtt/
sudo snap install --dangerous edgex-device-mqtt_3.1.0-dev.2_amd64.snap
...
PASS
```
```
$ LOCAL_PLATFORM_SNAP=edgex-snap-testing/edgexfoundry_3.1.0-dev.3_amd64.snap \
LOCAL_SERVICE_SNAP=edgex-device-mqtt_3.1.0-dev.2_amd64.snap \
go test -v -failfast -count 1 ./test/suites/device-mqtt
[exec] sudo snap install --dangerous edgex-device-mqtt_3.1.0-dev.2_amd64.snap
[exec] sudo snap install --dangerous edgexfoundry_3.1.0-dev.3_amd64.snap
...
PASS
```




