### PR TITLE
Add channel input for Github snap testing workflow

### DIFF
--- a/.github/workflows/snap-testing.yml
+++ b/.github/workflows/snap-testing.yml
@@ -17,6 +17,26 @@ on:
         required: false
         default: false
         type: boolean
+      channel:
+        description: Channel (optional)
+        required: false
+        default: "latest/edge"
+        type: choice
+        options: 
+          - 'latest/edge'
+          - 'latest/beta'
+          - 'latest/candidate'
+          - 'latest/stable'
+      platform_channel:
+        description: Platform channel (optional)
+        required: false
+        default: "latest/edge"
+        type: choice
+        options: 
+          - 'latest/edge'
+          - 'latest/beta'
+          - 'latest/candidate'
+          - 'latest/stable'
 
 jobs:
   build_and_test:

--- a/.github/workflows/snap-testing.yml
+++ b/.github/workflows/snap-testing.yml
@@ -111,7 +111,7 @@ jobs:
         with:
           name: ${{matrix.name}}
           snap: ${{ inputs.localBuild == true && steps.build.outputs.snap || '' }}
-          channel: ${{matrix.channel}}
-          platform_channel: ${{matrix.platform_channel}}
+          channel: ${{ github.event.inputs.channel }}
+          platform_channel: ${{ github.event.inputs.platform_channel }}
           full_config_test: true
 


### PR DESCRIPTION
The PR has been tested on my local fork's [github action](https://github.com/MonicaisHer/edgex-snap-testing/actions/runs/5312833606) with the `channel` and `platform_channel` set to "latest/beta". The device-rest testing failed because it has not been promoted to "latest/beta".